### PR TITLE
feature/#1 : API 응답 통일

### DIFF
--- a/src/main/java/com/itstime/xpact/global/exception/ErrorCode.java
+++ b/src/main/java/com/itstime/xpact/global/exception/ErrorCode.java
@@ -1,0 +1,16 @@
+package com.itstime.xpact.global.exception;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+public enum ErrorCode {
+
+    TEST(HttpStatus.INTERNAL_SERVER_ERROR, "500 에러", "Test Error"),;
+
+    private final HttpStatus httpStatus;
+    private final String code;
+    private final String message;
+}

--- a/src/main/java/com/itstime/xpact/global/response/ApiResponse.java
+++ b/src/main/java/com/itstime/xpact/global/response/ApiResponse.java
@@ -1,0 +1,50 @@
+package com.itstime.xpact.global.response;
+
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import com.itstime.xpact.global.exception.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@AllArgsConstructor
+@JsonPropertyOrder({"success", "code", "message", "data"})
+public class ApiResponse<T> {
+
+    private Boolean success;
+
+    private String code;
+
+    private String message;
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private T data;
+
+    /**
+     * 반환할 데이터가 없고, API응답이 성공인 경우 호출하는 메서드
+     * @return ApiResponse(true, String.valueOf(HttpStatus.OK.value()), "OK", null)
+     */
+    public static ApiResponse<?> onSuccess() {
+        return new ApiResponse<>(true, String.valueOf(HttpStatus.OK.value()), "OK", null);
+    }
+
+    /**
+     * 반환할 데이터 (data)가 있고, API응답이 성공인 경우 호출하는 메서드
+     * @param data
+     * @return ApiResponse(true, String.valueOf(HttpStatus.OK.value()), "OK", data)
+     */
+    public static <T> ApiResponse<T> onSuccess(T data) {
+        return new ApiResponse<>(true, String.valueOf(HttpStatus.OK.value()), "OK", data);
+    }
+
+    /**
+     * 비즈니스 로직에서 예외 발생 시 호출하는 실패 메서드
+     * @param errorCode
+     * @return ApiResponse(false, errorCode.getCode(), errorCode.getMessage(), null)
+     */
+    public static <T> ApiResponse<T> onFailure(ErrorCode errorCode) {
+        return new ApiResponse<>(false, errorCode.getCode(), errorCode.getMessage(), null);
+    }
+}

--- a/src/main/java/com/itstime/xpact/global/test/TestController.java
+++ b/src/main/java/com/itstime/xpact/global/test/TestController.java
@@ -1,0 +1,28 @@
+package com.itstime.xpact.global.test;
+
+import com.itstime.xpact.global.exception.ErrorCode;
+import com.itstime.xpact.global.response.ApiResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/test")
+public class TestController {
+
+    @GetMapping("/no-data")
+    public ApiResponse<?> testOnSuccess() {
+        return ApiResponse.onSuccess();
+    }
+
+    @GetMapping("/data")
+    public ApiResponse<?> testOnSuccessResult() {
+        String message = "test result";
+        return ApiResponse.onSuccess(message);
+    }
+
+    @GetMapping("/failure")
+    public ApiResponse<?> testOnFailure() {
+        return ApiResponse.onFailure(ErrorCode.TEST);
+    }
+}

--- a/src/main/java/com/itstime/xpact/global/test/TestController.java
+++ b/src/main/java/com/itstime/xpact/global/test/TestController.java
@@ -2,25 +2,31 @@ package com.itstime.xpact.global.test;
 
 import com.itstime.xpact.global.exception.ErrorCode;
 import com.itstime.xpact.global.response.ApiResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/test")
+@Tag(name = "응답 테스트 API")
 public class TestController {
 
+    @Operation(summary = "API 응답 테스트 (데이터 X, 성공)", description = "데이터가 없는 성공한 API 응답을 내놓습니다.")
     @GetMapping("/no-data")
     public ApiResponse<?> testOnSuccess() {
         return ApiResponse.onSuccess();
     }
 
+    @Operation(summary = "API 응답 테스트 (데이터 O, 성공)", description = "데이터가 있는 성공한 API 응답을 내놓습니다.")
     @GetMapping("/data")
     public ApiResponse<?> testOnSuccessResult() {
         String message = "test result";
         return ApiResponse.onSuccess(message);
     }
 
+    @Operation(summary = "API 응답 테스트 (실패)", description = "비즈니스 로직에서 실패한 API 응답을 내놓습니다.")
     @GetMapping("/failure")
     public ApiResponse<?> testOnFailure() {
         return ApiResponse.onFailure(ErrorCode.TEST);


### PR DESCRIPTION
## 🔧 관련 이슈
- closed #1 

## 📌 PR 유형
- [x] 새로운 기능 추가

## 📝 작업 내용
### ErrorCode
- httpStatus, code, message의 필드값 생성
- 예) member가 존재하지 않을 때 
```java
MEMBER_NOT_EXISTS(HttpStatus.INTERNAL_SERVER_ERROR, "M001", "해당 멤버가 존재하지 않습니다")
```

### ApiResponse
- success, code, message, result 필드
- onSuccess, onFailure 정적 팩토리 메서드 생성

### ApiResponse Controller
- ApiResponse 테스트 컨트롤러
- 후에 테스트 코드 작성 예정

## ✏️ 기타
