### PR TITLE
Fix/#7/experience entity fix

### DIFF
--- a/src/main/java/com/itstime/xpact/domain/experience/common/ExperienceType.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/common/ExperienceType.java
@@ -1,0 +1,14 @@
+package com.itstime.xpact.domain.experience.common;
+
+public enum ExperienceType {
+    INTERN,
+    EXTERNAL_ACTIVITIES,
+    CONTEST,
+    PROJECT,
+    CERTIFICATES,
+    ACADEMIC_CLUB,
+    EDUCATION,
+    VOLUNTEER_WORK,
+    STUDY_ABROAD,
+    ETC,;
+}

--- a/src/main/java/com/itstime/xpact/domain/experience/common/Status.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/common/Status.java
@@ -1,0 +1,5 @@
+package com.itstime.xpact.domain.experience.common;
+
+public enum Status {
+    STASH, SAVE
+}

--- a/src/main/java/com/itstime/xpact/domain/experience/entity/Experience.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/entity/Experience.java
@@ -1,6 +1,7 @@
 package com.itstime.xpact.domain.experience.entity;
 
 import com.itstime.xpact.domain.common.BaseEntity;
+import com.itstime.xpact.domain.experience.common.ExperienceType;
 import com.itstime.xpact.domain.member.entity.Member;
 import com.itstime.xpact.domain.recruit.entity.ExperienceKeyword;
 import jakarta.persistence.*;
@@ -20,6 +21,11 @@ public abstract class Experience extends BaseEntity {
     @Column(name = "experience_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    // TODO 경험 유형 enum이 아닌 테이블로 추가 고려
+    @Column(name = "type", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private ExperienceType type;
 
     @Column(name = "title", nullable = false)
     private String title;

--- a/src/main/java/com/itstime/xpact/domain/experience/entity/Experience.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/entity/Experience.java
@@ -12,7 +12,9 @@ import java.util.List;
 
 @Entity
 @Table(name = "experience")
-public class Experience extends BaseEntity {
+@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
+@DiscriminatorColumn(name = "form_type")
+public abstract class Experience extends BaseEntity {
 
     @Id
     @Column(name = "experience_id")
@@ -30,12 +32,6 @@ public class Experience extends BaseEntity {
 
     @Column(name = "end_date")
     private LocalDate endDate;
-
-    @Column(name = "role")
-    private String role;
-
-    @Column(name = "perform")
-    private String perform;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id", nullable = false)

--- a/src/main/java/com/itstime/xpact/domain/experience/entity/Experience.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/entity/Experience.java
@@ -2,6 +2,7 @@ package com.itstime.xpact.domain.experience.entity;
 
 import com.itstime.xpact.domain.common.BaseEntity;
 import com.itstime.xpact.domain.experience.common.ExperienceType;
+import com.itstime.xpact.domain.experience.common.Status;
 import com.itstime.xpact.domain.member.entity.Member;
 import com.itstime.xpact.domain.recruit.entity.ExperienceKeyword;
 import jakarta.persistence.*;
@@ -21,6 +22,10 @@ public abstract class Experience extends BaseEntity {
     @Column(name = "experience_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+
+    @Column(name = "status", nullable = false)
+    @Enumerated(EnumType.STRING)
+    private Status status;
 
     // TODO 경험 유형 enum이 아닌 테이블로 추가 고려
     @Column(name = "type", nullable = false)

--- a/src/main/java/com/itstime/xpact/domain/experience/entity/SimpleForm.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/entity/SimpleForm.java
@@ -1,0 +1,16 @@
+package com.itstime.xpact.domain.experience.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+@Entity
+@DiscriminatorValue("SIMPLE_FORM")
+public class SimpleForm extends Experience {
+
+    @Column(name = "role", nullable = false)
+    private String role;
+
+    @Column(name = "perform", nullable = false)
+    private String perform;
+}

--- a/src/main/java/com/itstime/xpact/domain/experience/entity/StarForm.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/entity/StarForm.java
@@ -1,0 +1,22 @@
+package com.itstime.xpact.domain.experience.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.DiscriminatorValue;
+import jakarta.persistence.Entity;
+
+@Entity
+@DiscriminatorValue("STAR_FORM")
+public class StarForm extends Experience {
+
+    @Column(name = "situation", nullable = false)
+    private String situation;
+
+    @Column(name = "task", nullable = false)
+    private String task;
+
+    @Column(name = "action", nullable = false)
+    private String action;
+
+    @Column(name = "result", nullable = false)
+    private String result;
+}


### PR DESCRIPTION
## 🔧 관련 이슈
- close #7

## 📌 PR 유형
> 어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가

## 📝 작업 내용
- 경험 엔티티 변경
- Entity 상속을 이용 두 가지 다른 양식을 구현
- `SINGLE_TABLE` 전략으로 하나의 테이블에서 관리
```java
@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
```
- Experience 엔티티에서 `form_type`을 통해 STAR양식(`STAR_FORM`)인지 간결양식(`SIMPLE_FORM`)인지 구분
```java
@Entity
@Table(name = "experience")
@Inheritance(strategy = InheritanceType.SINGLE_TABLE)
@DiscriminatorColumn(name = "form_type")
public abstract class Experience extends BaseEntity {
    ...
}

@Entity
@DiscriminatorValue("SIMPLE_FORM")
public class SimpleForm extends Experience {

    @Column(name = "role", nullable = false)
    private String role;

    @Column(name = "perform", nullable = false)
    private String perform;
}

@Entity
@DiscriminatorValue("STAR_FORM")
public class StarForm extends Experience {

    @Column(name = "situation", nullable = false)
    private String situation;

    @Column(name = "task", nullable = false)
    private String task;

    @Column(name = "action", nullable = false)
    private String action;

    @Column(name = "result", nullable = false)
    private String result;
}
```

- Experience 엔티티에 저장 유형 추가
- Enum으로 STASH(임시저장), SAVE(저장) 설정

---

- 경험 유형 설정 (임시로 설정한 Column -> 빠른 개발을 위해)
- Enum으로 9가지의 유형 설정
- 추후 테이블로 변경 예정 

## ✏️ 기타
