### PR TITLE
Feature/#55/save desire recruit

### DIFF
--- a/src/main/java/com/itstime/xpact/domain/member/controller/EducationController.java
+++ b/src/main/java/com/itstime/xpact/domain/member/controller/EducationController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 @Controller
 @RequestMapping("/api/educations")
 @RequiredArgsConstructor
-@Tag(name = "Educations API Controller", description = "학력사항 저장을 위한 API")
+@Tag(name = "학력 API Controller", description = "학력사항 저장을 위한 API")
 public class EducationController {
 
     private final EducationService educationService;

--- a/src/main/java/com/itstime/xpact/domain/member/controller/MemberController.java
+++ b/src/main/java/com/itstime/xpact/domain/member/controller/MemberController.java
@@ -31,10 +31,14 @@ public class MemberController {
     }
 
     // 회원 정보 입력
-    @Operation(summary = "회원 정보 입력 API")
-    @PostMapping("")
+    @Operation(summary = "회원 정보 입력 API", description = """
+            회원 프로필의 정보를 등록합니다.<br>
+            이름, 사진, 나이에 대한 정보에 대한 등록입니다.<br>
+            학력 및 희망 직무에 대한 저장은 다른 요청을 보내주세요.<br>
+            """)
     @PatchMapping("")
     public ResponseEntity<RestResponse<?>> saveMyInfo(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "회원 정보 등록 DTO", required = true)
             @RequestHeader("Authorization") String authToken,
             @RequestBody MemberInfoRequestDto requestDto
             ) {

--- a/src/main/java/com/itstime/xpact/domain/member/controller/MemberController.java
+++ b/src/main/java/com/itstime/xpact/domain/member/controller/MemberController.java
@@ -33,6 +33,7 @@ public class MemberController {
     // 회원 정보 입력
     @Operation(summary = "회원 정보 입력 API")
     @PostMapping("")
+    @PatchMapping("")
     public ResponseEntity<RestResponse<?>> saveMyInfo(
             @RequestHeader("Authorization") String authToken,
             @RequestBody MemberInfoRequestDto requestDto

--- a/src/main/java/com/itstime/xpact/domain/member/dto/request/EducationSaveRequestDto.java
+++ b/src/main/java/com/itstime/xpact/domain/member/dto/request/EducationSaveRequestDto.java
@@ -2,10 +2,6 @@ package com.itstime.xpact.domain.member.dto.request;
 
 import com.itstime.xpact.domain.member.common.SchoolStatus;
 import io.swagger.v3.oas.annotations.media.Schema;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
-import lombok.RequiredArgsConstructor;
 
 import java.time.LocalDate;
 

--- a/src/main/java/com/itstime/xpact/domain/member/dto/request/EducationSaveRequestDto.java
+++ b/src/main/java/com/itstime/xpact/domain/member/dto/request/EducationSaveRequestDto.java
@@ -30,8 +30,8 @@ public record EducationSaveRequestDto(
         LocalDate endedAt
 ) {
 
-        public static EducationSaveRequestDto of(String name, String major) {
-                return new EducationSaveRequestDto(name, major, null, null, null);
+        public static EducationSaveRequestDto of(String name, String major, SchoolStatus schoolStatus) {
+                return new EducationSaveRequestDto(name, major, schoolStatus, null, null);
         }
 
         public static EducationSaveRequestDto of(String name, String major, SchoolStatus status, LocalDate startedAt, LocalDate endedAt) {

--- a/src/main/java/com/itstime/xpact/domain/member/dto/request/MemberInfoRequestDto.java
+++ b/src/main/java/com/itstime/xpact/domain/member/dto/request/MemberInfoRequestDto.java
@@ -1,9 +1,6 @@
 package com.itstime.xpact.domain.member.dto.request;
 
-import com.itstime.xpact.domain.recruit.entity.Recruit;
 import io.swagger.v3.oas.annotations.media.Schema;
-
-import java.time.LocalDate;
 
 @Schema
 public record MemberInfoRequestDto(
@@ -15,22 +12,6 @@ public record MemberInfoRequestDto(
         String imgurl,
 
         @Schema(description = "회원 나이")
-        Integer age,
-
-        @Schema(description = "회원 최종 학력 한 줄",
-                example = "잇타대학교 잇타학과 재학")
-        String schoolInfo,
-
-        @Schema(description = "희망 직무",
-                example = "회계사")
-        String desiredRecruit,
-
-        @Schema(description = "입학 날짜",
-        example = "2025-03-02")
-        LocalDate startedAt,
-
-        @Schema(description = "졸업 날짜",
-        example = "2025-03-02")
-        LocalDate endedAt
+        Integer age
 ) {
 }

--- a/src/main/java/com/itstime/xpact/domain/member/dto/request/MemberInfoRequestDto.java
+++ b/src/main/java/com/itstime/xpact/domain/member/dto/request/MemberInfoRequestDto.java
@@ -23,7 +23,7 @@ public record MemberInfoRequestDto(
 
         @Schema(description = "희망 직무",
                 example = "회계사")
-        Recruit recruit,
+        String desiredRecruit,
 
         @Schema(description = "입학 날짜",
         example = "2025-03-02")

--- a/src/main/java/com/itstime/xpact/domain/member/dto/response/MemberInfoResponseDto.java
+++ b/src/main/java/com/itstime/xpact/domain/member/dto/response/MemberInfoResponseDto.java
@@ -23,8 +23,8 @@ public record MemberInfoResponseDto (
         String education,
 
         @Schema(description = "희망 직무",
-        example = "회계사")
-        String recruit,
+        example = "서비스 기획자")
+        String desiredDetailRecruit,
 
         @Schema(description = "입학 날짜",
                 example = "2025-03-02")

--- a/src/main/java/com/itstime/xpact/domain/member/entity/Education.java
+++ b/src/main/java/com/itstime/xpact/domain/member/entity/Education.java
@@ -1,6 +1,7 @@
 package com.itstime.xpact.domain.member.entity;
 
 import com.itstime.xpact.domain.member.common.SchoolStatus;
+import com.itstime.xpact.domain.member.dto.request.EducationSaveRequestDto;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -43,5 +44,13 @@ public class Education {
 
     public void setMember(Member member) {
         this.member = member;
+    }
+
+    public void updateEducation(EducationSaveRequestDto requestDto) {
+        this.educationName = requestDto.name();
+        this.major = requestDto.major();
+        this.schoolStatus = requestDto.schoolStatus();
+        this.startedAt = requestDto.startedAt();
+        this.endedAt = requestDto.endedAt() != null ? requestDto.endedAt() : null;
     }
 }

--- a/src/main/java/com/itstime/xpact/domain/member/entity/Member.java
+++ b/src/main/java/com/itstime/xpact/domain/member/entity/Member.java
@@ -7,7 +7,6 @@ import com.itstime.xpact.domain.member.common.Role;
 import com.itstime.xpact.domain.member.common.Type;
 import com.itstime.xpact.domain.member.dto.request.MemberInfoRequestDto;
 import com.itstime.xpact.domain.member.dto.response.MemberInfoResponseDto;
-import com.itstime.xpact.domain.recruit.entity.Recruit;
 import com.itstime.xpact.domain.scrap.entity.Scrap;
 import jakarta.persistence.*;
 import lombok.*;
@@ -92,6 +91,8 @@ public class Member extends BaseEntity {
                 .education(member.getEducation().getEducationName())
                 .age(member.getAge() != null ? member.getAge() : 0)
                 .desiredDetailRecruit(member.getDesiredRecruit() != null ? member.getDesiredRecruit() : null)
+                .startedAt(member.getEducation().getStartedAt() != null ? member.getEducation().getStartedAt() : null)
+                .endedAt(member.getEducation().getEndedAt() != null ? member.getEducation().getEndedAt() : null)
                 .build();
     }
 

--- a/src/main/java/com/itstime/xpact/domain/member/entity/Member.java
+++ b/src/main/java/com/itstime/xpact/domain/member/entity/Member.java
@@ -65,9 +65,8 @@ public class Member extends BaseEntity {
     @OneToOne(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.EAGER)
     private Education education;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "recruit_id")
-    private Recruit recruit;
+    @Column(name = "desired_recruit")
+    private String desiredRecruit;
 
     @OneToMany(mappedBy = "member", cascade = CascadeType.ALL)
     private List<Experience> experiences = new ArrayList<>();
@@ -92,7 +91,7 @@ public class Member extends BaseEntity {
                 .imgurl(member.getImgurl())
                 .education(member.getEducation().getEducationName())
                 .age(member.getAge() != null ? member.getAge() : 0)
-                .recruit(member.getRecruit() != null ? member.getRecruit().getName() : null)
+                .desiredDetailRecruit(member.getDesiredRecruit() != null ? member.getDesiredRecruit() : null)
                 .build();
     }
 
@@ -100,12 +99,16 @@ public class Member extends BaseEntity {
         if (requestDto.name() != null) this.name = requestDto.name();
         if (requestDto.age() != null) this.age = requestDto.age();
         if (requestDto.imgurl() != null) this.imgurl = requestDto.imgurl();
-        //if (requestDto.schoolInfo() != null) this.education = requestDto.schoolInfo();
-        if (requestDto.recruit() != null) this.recruit = requestDto.recruit();
     }
 
+    // 최종학력만 저장
     public void setEducation(Education education) {
         this.education = education;
         education.setMember(this);
+    }
+
+    // 희망직무 저장
+    public void setDesiredRecruit(String desiredRecruit) {
+        this.desiredRecruit = desiredRecruit;
     }
 }

--- a/src/main/java/com/itstime/xpact/domain/member/entity/School.java
+++ b/src/main/java/com/itstime/xpact/domain/member/entity/School.java
@@ -1,9 +1,8 @@
 package com.itstime.xpact.domain.member.entity;
 
+import com.itstime.xpact.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
-
-import java.util.List;
 
 @Entity
 @Table(name = "school",
@@ -11,7 +10,7 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class School {
+public class School extends BaseEntity {
 
     @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "school_id", nullable = false)

--- a/src/main/java/com/itstime/xpact/domain/member/service/EducationService.java
+++ b/src/main/java/com/itstime/xpact/domain/member/service/EducationService.java
@@ -136,39 +136,13 @@ public class EducationService {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_EXISTS));
 
+        // 최초 저장과 수정의 경우 구분
         Education education = educationRepository.findByMemberId(member.getId())
                 .orElseThrow(() -> CustomException.of(ErrorCode.EDUCATION_NOT_FOUND));
 
-        // 값이 존재할 경우에만 업데이트
-        if (requestDto.name() != null) {
-            education.setSchoolName(requestDto.name());
-        }
-
-        if (requestDto.major() != null) {
-            education.setMajor(requestDto.major());
-        }
-
-        if (requestDto.schoolStatus() != null) {
-            education.setSchoolStatus(requestDto.schoolStatus());
-        }
-
-        if (requestDto.startedAt() != null) {
-            education.setStartedAt(requestDto.startedAt());
-        }
-
-        if (requestDto.endedAt() != null) {
-            education.setEndedAt(requestDto.endedAt());
-        }
-
-        // 학교명 또는 전공이 변경되었으면 educationName 재생성
-        if (requestDto.name() != null || requestDto.major() != null) {
-            String educationName = createEducationName(EducationSaveRequestDto.of(
-                    requestDto.name() != null ? requestDto.name() : education.getSchoolName(),
-                    requestDto.major() != null ? requestDto.major() : education.getMajor(),
-                    requestDto.schoolStatus() != null ? requestDto.schoolStatus() : education.getSchoolStatus()
-            ));
-            education.setEducationName(educationName);
-        }
+        education.updateEducation(requestDto);
+        String educationName = createEducationName(requestDto);
+        education.setEducationName(educationName);
 
         return EducationSaveResponseDto.toDto(education);
     }

--- a/src/main/java/com/itstime/xpact/domain/member/service/MemberService.java
+++ b/src/main/java/com/itstime/xpact/domain/member/service/MemberService.java
@@ -38,7 +38,9 @@ public class MemberService {
     public MemberInfoResponseDto saveMyinfo(MemberInfoRequestDto requestDto) throws CustomException {
 
         // Member 조회
-       Member member = securityProvider.getCurrentMember();
+       Long memberId = securityProvider.getCurrentMemberId();
+       Member member = memberRepository.findById(memberId)
+                       .orElseThrow(() -> CustomException.of(ErrorCode.MEMBER_NOT_EXISTS));
 
         member.updateMemberInfo(requestDto);
         return member.toMemberInfoResponseDto(member);

--- a/src/main/java/com/itstime/xpact/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/com/itstime/xpact/domain/recruit/controller/RecruitController.java
@@ -1,0 +1,76 @@
+package com.itstime.xpact.domain.recruit.controller;
+
+import com.itstime.xpact.domain.recruit.dto.request.DesiredRecruitRequestDto;
+import com.itstime.xpact.domain.recruit.service.RecruitService;
+import com.itstime.xpact.global.response.RestResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/recruits")
+@RequiredArgsConstructor
+@Tag(name = "직무 저장 API Controller", description = "희망직무 저장을 위한 API 입니다.")
+public class RecruitController {
+
+    private final RecruitService recruitService;
+
+    @GetMapping("/name")
+    public ResponseEntity<RestResponse<?>> findAllName(
+            @RequestHeader("Authorization") String token) {
+
+        return ResponseEntity.ok(
+                RestResponse.ok(
+                        recruitService.readAllRecruit()
+                )
+        );
+    }
+
+    @GetMapping("/name/search")
+    public ResponseEntity<RestResponse<?>> searchRecruit(
+            @RequestHeader("Authorization") String token,
+            @RequestParam String keyword
+    ) {
+        return ResponseEntity.ok(
+                RestResponse.ok(
+                        recruitService.autocompleteName(keyword)
+                )
+        );
+    }
+
+    @GetMapping("/{name}/detail")
+    public ResponseEntity<RestResponse<?>> findAllDetailRecruit(
+            @RequestHeader("Authorization") String token,
+            @PathVariable String name
+    ) {
+        return ResponseEntity.ok(
+                RestResponse.ok(recruitService.readAllDetailRecruits(name))
+        );
+    }
+
+    @GetMapping("/{name}/detail/search")
+    public ResponseEntity<RestResponse<?>> searchDetailRecruit(
+            @RequestHeader("Authorization") String token,
+            @PathVariable String name,
+            @RequestParam String keyword
+    ) {
+        return ResponseEntity.ok(
+                RestResponse.ok(
+                        recruitService.autocompleteDetail(name, keyword)
+                )
+        );
+    }
+
+    @PostMapping
+    public ResponseEntity<RestResponse<?>> saveDesiredRecruit(
+            @RequestHeader("Authorization") String token,
+            @RequestBody DesiredRecruitRequestDto requestDto
+            ) {
+        return ResponseEntity.ok(
+                RestResponse.ok(
+                        recruitService.saveDesiredRecruit(requestDto)
+                )
+        );
+    }
+}

--- a/src/main/java/com/itstime/xpact/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/com/itstime/xpact/domain/recruit/controller/RecruitController.java
@@ -3,6 +3,7 @@ package com.itstime.xpact.domain.recruit.controller;
 import com.itstime.xpact.domain.recruit.dto.request.DesiredRecruitRequestDto;
 import com.itstime.xpact.domain.recruit.service.RecruitService;
 import com.itstime.xpact.global.response.RestResponse;
+import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -16,6 +17,10 @@ public class RecruitController {
 
     private final RecruitService recruitService;
 
+    @Operation(summary = "산업 별 전체 조회 API", description = """
+    직무 전체 산업 부문을 반환합니다.<br>
+    Header에 accessToken 값을 넣어주세요.
+    """)
     @GetMapping("/name")
     public ResponseEntity<RestResponse<?>> findAllName(
             @RequestHeader("Authorization") String token) {
@@ -27,6 +32,10 @@ public class RecruitController {
         );
     }
 
+    @Operation(summary = "산업 별 검색 자동완성 API", description = """
+    산업 부문 중 검색과 일치하는 부문에 대하여 반환합니다.<br>
+    Header에 accessToken 값을 넣어주세요.
+    """)
     @GetMapping("/name/search")
     public ResponseEntity<RestResponse<?>> searchRecruit(
             @RequestHeader("Authorization") String token,
@@ -39,6 +48,10 @@ public class RecruitController {
         );
     }
 
+    @Operation(summary = "상세 직무 전체 조회 API", description = """
+    희망 산업을 선택 후, 그 산업에 해당되는 직무들을 반환합니다.<br>
+    Header에 accessToken 값을 넣어주세요.
+    """)
     @GetMapping("/{name}/detail")
     public ResponseEntity<RestResponse<?>> findAllDetailRecruit(
             @RequestHeader("Authorization") String token,
@@ -49,6 +62,10 @@ public class RecruitController {
         );
     }
 
+    @Operation(summary = "상세 직무 검색 자동완성 API", description = """
+    희망 산업을 선택 후, 상세 직무 검색 시 검색어와 일치하는 상세직무들을 반환합니다.<br>
+    Header에 accessToken 값을 넣어주세요.
+    """)
     @GetMapping("/{name}/detail/search")
     public ResponseEntity<RestResponse<?>> searchDetailRecruit(
             @RequestHeader("Authorization") String token,
@@ -62,8 +79,13 @@ public class RecruitController {
         );
     }
 
+    @Operation(summary = "회원 희망 직무 저장 API", description = """
+    회원이 여태 선택한 것을 바탕으로 희망 직무 정보를 저장합니다.<br>
+    Header에 accessToken 값을 넣어주세요.
+    """)
     @PatchMapping
     public ResponseEntity<RestResponse<?>> updateDesiredRecruit(
+            @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "희망 직무 요청 DTO", required = true)
             @RequestHeader("Authorization") String token,
             @RequestBody DesiredRecruitRequestDto requestDto
     ) {

--- a/src/main/java/com/itstime/xpact/domain/recruit/controller/RecruitController.java
+++ b/src/main/java/com/itstime/xpact/domain/recruit/controller/RecruitController.java
@@ -11,7 +11,7 @@ import org.springframework.web.bind.annotation.*;
 @RestController
 @RequestMapping("/api/recruits")
 @RequiredArgsConstructor
-@Tag(name = "직무 저장 API Controller", description = "희망직무 저장을 위한 API 입니다.")
+@Tag(name = "희망 직무 저장 API Controller", description = "희망 직무 저장을 위한 API 입니다.")
 public class RecruitController {
 
     private final RecruitService recruitService;
@@ -62,14 +62,14 @@ public class RecruitController {
         );
     }
 
-    @PostMapping
-    public ResponseEntity<RestResponse<?>> saveDesiredRecruit(
+    @PatchMapping
+    public ResponseEntity<RestResponse<?>> updateDesiredRecruit(
             @RequestHeader("Authorization") String token,
             @RequestBody DesiredRecruitRequestDto requestDto
-            ) {
+    ) {
         return ResponseEntity.ok(
                 RestResponse.ok(
-                        recruitService.saveDesiredRecruit(requestDto)
+                        recruitService.updateDesiredRecruit(requestDto)
                 )
         );
     }

--- a/src/main/java/com/itstime/xpact/domain/recruit/dto/request/DesiredRecruitRequestDto.java
+++ b/src/main/java/com/itstime/xpact/domain/recruit/dto/request/DesiredRecruitRequestDto.java
@@ -1,0 +1,15 @@
+package com.itstime.xpact.domain.recruit.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "회원이 희망 직무를 저장할 때 사용하는 DTO")
+public record DesiredRecruitRequestDto(
+        @Schema(description = "희망 산업 분야",
+        example = "법률·법무·회계")
+        String recruitName,
+
+        @Schema(description = "희망 상세 직군 분야",
+        example = "법률사무원")
+        String detailRecruitName
+) {
+}

--- a/src/main/java/com/itstime/xpact/domain/recruit/dto/response/DesiredRecruitResponseDto.java
+++ b/src/main/java/com/itstime/xpact/domain/recruit/dto/response/DesiredRecruitResponseDto.java
@@ -1,0 +1,17 @@
+package com.itstime.xpact.domain.recruit.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+@Builder
+@Schema
+public record DesiredRecruitResponseDto (
+    @Schema(description = "희망 산업 분야",
+            example = "법률·법무·회계")
+    String recruitName,
+
+    @Schema(description = "희망 상세 직군 분야",
+            example = "법률사무원")
+    String detailRecruitName
+) {
+}

--- a/src/main/java/com/itstime/xpact/domain/recruit/entity/Recruit.java
+++ b/src/main/java/com/itstime/xpact/domain/recruit/entity/Recruit.java
@@ -1,7 +1,6 @@
 package com.itstime.xpact.domain.recruit.entity;
 
 import com.itstime.xpact.domain.common.BaseEntity;
-import com.itstime.xpact.domain.member.entity.Member;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/itstime/xpact/domain/recruit/repository/DetailRecruitRepository.java
+++ b/src/main/java/com/itstime/xpact/domain/recruit/repository/DetailRecruitRepository.java
@@ -2,8 +2,18 @@ package com.itstime.xpact.domain.recruit.repository;
 
 import com.itstime.xpact.domain.recruit.entity.DetailRecruit;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface DetailRecruitRepository extends JpaRepository<DetailRecruit, Long> {
+
+    @Query("SELECT d.name FROM DetailRecruit d WHERE d.recruit.id = :recruitId")
+    List<String> findAllByRecruitId(@Param("recruitId") Long recruitId);
+
+    @Query("SELECT d.name FROM DetailRecruit d WHERE d.recruit.id = :recuruitId")
+    List<String> findDetailRecruitNamesByRecruitId(@Param("recruitId") Long recruitId);
 }

--- a/src/main/java/com/itstime/xpact/domain/recruit/repository/DetailRecruitRepository.java
+++ b/src/main/java/com/itstime/xpact/domain/recruit/repository/DetailRecruitRepository.java
@@ -14,6 +14,6 @@ public interface DetailRecruitRepository extends JpaRepository<DetailRecruit, Lo
     @Query("SELECT d.name FROM DetailRecruit d WHERE d.recruit.id = :recruitId")
     List<String> findAllByRecruitId(@Param("recruitId") Long recruitId);
 
-    @Query("SELECT d.name FROM DetailRecruit d WHERE d.recruit.id = :recuruitId")
+    @Query("SELECT d.name FROM DetailRecruit d WHERE d.recruit.id = :recruitId")
     List<String> findDetailRecruitNamesByRecruitId(@Param("recruitId") Long recruitId);
 }

--- a/src/main/java/com/itstime/xpact/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/itstime/xpact/domain/recruit/repository/RecruitRepository.java
@@ -2,6 +2,7 @@ package com.itstime.xpact.domain.recruit.repository;
 
 import com.itstime.xpact.domain.recruit.entity.Recruit;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -12,5 +13,6 @@ public interface RecruitRepository extends JpaRepository<Recruit, Long> {
 
     Optional<Recruit> findByName(String name);
 
+    @Query("SELECT r.name FROM Recruit r")
     List<String> findAllNames();
 }

--- a/src/main/java/com/itstime/xpact/domain/recruit/repository/RecruitRepository.java
+++ b/src/main/java/com/itstime/xpact/domain/recruit/repository/RecruitRepository.java
@@ -4,10 +4,13 @@ import com.itstime.xpact.domain.recruit.entity.Recruit;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface RecruitRepository extends JpaRepository<Recruit, Long> {
 
     Optional<Recruit> findByName(String name);
+
+    List<String> findAllNames();
 }

--- a/src/main/java/com/itstime/xpact/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/itstime/xpact/domain/recruit/service/RecruitService.java
@@ -1,0 +1,115 @@
+package com.itstime.xpact.domain.recruit.service;
+
+import com.itstime.xpact.domain.member.entity.Member;
+import com.itstime.xpact.domain.member.util.TrieUtil;
+import com.itstime.xpact.domain.recruit.dto.request.DesiredRecruitRequestDto;
+import com.itstime.xpact.domain.recruit.dto.response.DesiredRecruitResponseDto;
+import com.itstime.xpact.domain.recruit.entity.Recruit;
+import com.itstime.xpact.domain.recruit.repository.DetailRecruitRepository;
+import com.itstime.xpact.domain.recruit.repository.RecruitRepository;
+import com.itstime.xpact.global.auth.SecurityProvider;
+import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class RecruitService {
+
+    private final SecurityProvider securityProvider;
+    private final TrieUtil trieUtil;
+
+    private final RecruitRepository recruitRepository;
+    private final DetailRecruitRepository detailRecruitRepository;
+
+
+    // 산업 전체 조회
+    @Transactional(readOnly = true)
+    public List<String> readAllRecruit() throws CustomException {
+
+        securityProvider.getCurrentMemberId();
+
+        return recruitRepository.findAllNames();
+    }
+
+    // 희망 산업 분야 검색 자동완성
+    @Transactional(readOnly = true)
+    public List<String> autocompleteName(String term) throws CustomException {
+
+        try {
+            securityProvider.getCurrentMemberId();
+
+            // Trie에 검색어 입력 내용 넣기
+            trieUtil.addAutocompleteKeyword(term);
+
+            // DB에 있는 Recruit name 전체 load
+            List<String> recruitNames = recruitRepository.findAllNames();
+            trieUtil.loadDatasIntoTrie(recruitNames);
+
+            // 일치 반환
+            return trieUtil.autocomplete(term);
+        } catch (Exception e) {
+            throw CustomException.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        } finally {
+            trieUtil.deleteAutocompleteKeyword(term);
+        }
+    }
+
+    // 상세 직군 전체 조회
+    @Transactional(readOnly = true)
+    public List<String> readAllDetailRecruits(String recruitName) throws CustomException {
+
+        Recruit recruit = recruitRepository.findByName(recruitName)
+                .orElseThrow(() -> CustomException.of(ErrorCode.RECRUIT_NOT_FOUND));
+        Long recruitId = recruit.getId();
+
+        return detailRecruitRepository.findAllByRecruitId(recruitId);
+    }
+
+    // 희망 상세 직군 검색 자동완성
+    @Transactional(readOnly = true)
+    public List<String> autocompleteDetail(String recruitName, String term) throws CustomException {
+
+        try {
+            securityProvider.getCurrentMemberId();
+
+            trieUtil.addAutocompleteKeyword(term);
+
+            Recruit recruit = recruitRepository.findByName(recruitName) // Recruit name Unique
+                    .orElseThrow(() -> CustomException.of(ErrorCode.RECRUIT_NOT_FOUND));
+
+            Long recruitId = recruit.getId();
+
+            List<String> detailRecruitNames = detailRecruitRepository.findDetailRecruitNamesByRecruitId(recruitId);
+            trieUtil.loadDatasIntoTrie(detailRecruitNames);
+
+            return trieUtil.autocomplete(term);
+        } catch (Exception e) {
+            throw CustomException.of(ErrorCode.INTERNAL_SERVER_ERROR);
+        } finally {
+            trieUtil.deleteAutocompleteKeyword(term);
+        }
+    }
+
+    // 희망 직군 저장
+    @Transactional
+    public DesiredRecruitResponseDto saveDesiredRecruit(DesiredRecruitRequestDto requestDto) throws CustomException {
+
+        Member member = securityProvider.getCurrentMember();
+
+        String desireRecruit = requestDto.detailRecruitName();
+        member.setDesiredRecruit(desireRecruit);
+
+        return DesiredRecruitResponseDto.builder()
+                .recruitName(requestDto.recruitName())
+                .detailRecruitName(requestDto.detailRecruitName())
+                .build();
+    }
+}

--- a/src/main/java/com/itstime/xpact/global/exception/ErrorCode.java
+++ b/src/main/java/com/itstime/xpact/global/exception/ErrorCode.java
@@ -60,9 +60,11 @@ public enum ErrorCode {
 
     // education
     EDUCATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "EE001", "저장된 학력 사항이 없습니다."),
+    EMPTY_SCHOOL_STATUS(HttpStatus.BAD_REQUEST, "EE002", "학력의 최종 상태를 입력하지 않았습니다."),
 
     // recruit
     RECRUIT_NOT_FOUND(HttpStatus.BAD_REQUEST, "RE001", "해당 직무가 존재하지 않습니다."),
+    EMPTY_DESIRED_RECRUIT(HttpStatus.BAD_REQUEST, "RE002", "희망 직무가 선택되지 않았습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/itstime/xpact/global/exception/ErrorCode.java
+++ b/src/main/java/com/itstime/xpact/global/exception/ErrorCode.java
@@ -60,6 +60,9 @@ public enum ErrorCode {
 
     // education
     EDUCATION_NOT_FOUND(HttpStatus.BAD_REQUEST, "EE001", "저장된 학력 사항이 없습니다."),
+
+    // recruit
+    RECRUIT_NOT_FOUND(HttpStatus.BAD_REQUEST, "RE001", "해당 직무가 존재하지 않습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/resources/application-dev.yaml
+++ b/src/main/resources/application-dev.yaml
@@ -39,3 +39,9 @@ spring:
 
 crawler:
   web-driver-path: ${DEV_WEB_DRIVER_PATH:}
+
+external:
+  api:
+    school:
+      service-key: ${SCHOOL_REST_API_KEY}
+      base-url: "http://openapi.academyinfo.go.kr"


### PR DESCRIPTION
## 🔧 관련 이슈
- closed #55 

## 📌 PR 유형
> 어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가

## 📝 작업 내용
- RecruitController, RecruitService : 회원 희망직무 저장 API 구현
- 산업 조회
<img src="https://github.com/user-attachments/assets/a3773109-df08-4ee1-a5cb-061fd7e7cc83"></br>
- 상세 직무 조회
<img src="https://github.com/user-attachments/assets/759bd7f8-e331-4bef-aec4-b10443a86af3" width="85%"></br>
- 회원 희망 직무 저장 및 실제 회원 DB에 저장 확인
<img src="https://github.com/user-attachments/assets/18e9730a-9201-419f-b2c9-08b6e5a5f420" width="85%"></br>
- 학력 저장은 Education DB에 따로 반영해야하기 때문에 최초 저장 POST / 수정 PATCH로 나누는 방식으로 변경


## ✏️ 기타
- application-dev.yml에 SCHOOL_REST_API_KEY 추가