### PR TITLE
fix/#57 : ThumbnailExperienceReadResponseDto에 Status필드 추가

### DIFF
--- a/src/main/java/com/itstime/xpact/domain/experience/dto/response/ThumbnailExperienceReadResponseDto.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/dto/response/ThumbnailExperienceReadResponseDto.java
@@ -2,6 +2,7 @@ package com.itstime.xpact.domain.experience.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.itstime.xpact.domain.experience.common.ExperienceType;
+import com.itstime.xpact.domain.experience.common.Status;
 import com.itstime.xpact.domain.experience.entity.Experience;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,12 +14,14 @@ public class ThumbnailExperienceReadResponseDto {
     private Long id;
     private String title;
     private ExperienceType experienceType;
+    private Status status;
 
     public static ThumbnailExperienceReadResponseDto of(Experience experience) {
         return ThumbnailExperienceReadResponseDto.builder()
                 .id(experience.getId())
                 .title(experience.getTitle())
                 .experienceType(experience.getExperienceType())
+                .status(experience.getStatus())
                 .build();
     }
 }


### PR DESCRIPTION
## 🔧 관련 이슈
- closed #57 

## 📌 PR 유형
> 어떤 변경 사항이 있나요?
- [x] 버그 수정

## 📝 작업 내용
- 경험 목록 조회 api에 status필드 추가

<img width="1268" alt="image" src="https://github.com/user-attachments/assets/6c3c6437-4177-485d-b8b6-3c4a486ffdbf" />


## ✏️ 기타
