### PR TITLE
Fix/#53/experience keyword

### DIFF
--- a/src/main/java/com/itstime/xpact/domain/experience/dto/request/ExperienceCreateRequestDto.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/dto/request/ExperienceCreateRequestDto.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -34,8 +35,7 @@ public class ExperienceCreateRequestDto {
     @Schema(description = "종료 일시", example = "2025-03-27")
     private LocalDate endDate;
 
-    @Schema(description = "키워드", example = "키워드를 입력하세요")
-    private String keyword;
+    private List<String> keywords;
 
     // STAR_FORM
     @Schema(description = "상황", example = "상황을 입력하세요")

--- a/src/main/java/com/itstime/xpact/domain/experience/dto/request/ExperienceUpdateRequestDto.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/dto/request/ExperienceUpdateRequestDto.java
@@ -7,6 +7,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Schema(description = "경험 수정 요청 DTO")
@@ -35,8 +36,8 @@ public class ExperienceUpdateRequestDto {
     @Schema(description = "종료 일시", example = "2025-03-27")
     private LocalDate endDate;
 
-    @Schema(description = "키워드", example = "키워드를 입력하세요")
-    private String keyword;
+    @Schema(description = "키워드")
+    private List<String> keywords;
 
     // STAR_FORM
     @Schema(description = "상황", example = "상황을 입력하세요")

--- a/src/main/java/com/itstime/xpact/domain/experience/dto/response/DetailExperienceReadResponseDto.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/dto/response/DetailExperienceReadResponseDto.java
@@ -11,6 +11,8 @@ import lombok.Builder;
 import lombok.Getter;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -26,6 +28,7 @@ public class DetailExperienceReadResponseDto {
     private LocalDate endDate;
     private FormType formType;
     private ExperienceType experienceType;
+    private List<String> keywords;
 
     // STAR 양식 부분
     private String situation;
@@ -52,6 +55,9 @@ public class DetailExperienceReadResponseDto {
                     .isEnded(experience.getIsEnded())
                     .startDate(experience.getStartDate())
                     .endDate(experience.getEndDate())
+                    .keywords(experience.getKeywords().stream()
+                            .map(Keyword::getName)
+                            .collect(Collectors.toList()))
                     .situation(null)
                     .task(null)
                     .action(null)
@@ -69,6 +75,9 @@ public class DetailExperienceReadResponseDto {
                     .isEnded(experience.getIsEnded())
                     .startDate(experience.getStartDate())
                     .endDate(experience.getEndDate())
+                    .keywords(experience.getKeywords().stream()
+                            .map(Keyword::getName)
+                            .collect(Collectors.toList()))
                     .situation(experience.getSituation())
                     .task(experience.getTask())
                     .action(experience.getAction())

--- a/src/main/java/com/itstime/xpact/domain/experience/entity/Experience.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/entity/Experience.java
@@ -13,13 +13,15 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDate;
+import java.util.List;
 
 @Getter
 @Entity
 @Table(name = "experience")
-@ToString(of = {"title", "keyword", "situation", "task", "action", "result", "role", "perform"})
-@SuperBuilder
+@Builder
 @NoArgsConstructor
+@AllArgsConstructor
+@ToString(of = {"title", "situation", "task", "action", "result", "role", "perform"})
 public class Experience extends BaseEntity {
 
     @Id
@@ -52,13 +54,9 @@ public class Experience extends BaseEntity {
     @Column(name = "summary", columnDefinition = "TEXT")
     private String summary;
 
-    @Column(name = "keyword")
-    private String keyword;
-
     @Column(name = "type", nullable = false)
     @Enumerated(EnumType.STRING)
     private ExperienceType experienceType;
-
 
     // STAR_FORM
     @Column(name = "situation")
@@ -81,12 +79,14 @@ public class Experience extends BaseEntity {
     @Column(name = "perform")
     private String perform;
 
+    @OneToMany(mappedBy = "experience", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
+    private List<Keyword> keywords;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
     private Member member;
 
-    @OneToOne()
+    @OneToOne
     @JoinColumn(name = "detail_recruit_id")
     private DetailRecruit detailRecruit;
 

--- a/src/main/java/com/itstime/xpact/domain/experience/entity/Experience.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/entity/Experience.java
@@ -29,35 +29,35 @@ public class Experience extends BaseEntity {
 
     @Column(name = "status", nullable = false)
     @Enumerated(EnumType.STRING)
-    protected Status status;
+    private Status status;
 
     @Column(name = "form_type", nullable = false)
     @Enumerated(EnumType.STRING)
-    protected FormType formType;
+    private FormType formType;
 
     @Column(name = "title", nullable = false)
-    protected String title;
+    private String title;
 
     @Column(name = "is_ended", nullable = false)
-    protected Boolean isEnded;
+    private Boolean isEnded;
 
     @Column(name = "start_date")
-    protected LocalDate startDate;
+    private LocalDate startDate;
 
     @Column(name = "end_date")
-    protected LocalDate endDate;
+    private LocalDate endDate;
 
     @Lob
     @Setter
     @Column(name = "summary", columnDefinition = "TEXT")
-    protected String summary;
+    private String summary;
 
     @Column(name = "keyword")
-    protected String keyword;
+    private String keyword;
 
     @Column(name = "type", nullable = false)
     @Enumerated(EnumType.STRING)
-    protected ExperienceType experienceType;
+    private ExperienceType experienceType;
 
 
     // STAR_FORM

--- a/src/main/java/com/itstime/xpact/domain/experience/entity/Experience.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/entity/Experience.java
@@ -13,7 +13,9 @@ import lombok.*;
 import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Entity
@@ -80,7 +82,7 @@ public class Experience extends BaseEntity {
     private String perform;
 
     @OneToMany(mappedBy = "experience", cascade = CascadeType.ALL, fetch = FetchType.LAZY, orphanRemoval = true)
-    private List<Keyword> keywords;
+    private List<Keyword> keywords = new ArrayList<>();
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "member_id")
@@ -98,7 +100,6 @@ public class Experience extends BaseEntity {
                 .isEnded(createRequestDto.getEndDate().isBefore(LocalDate.now()))
                 .startDate(createRequestDto.getStartDate())
                 .endDate(createRequestDto.getEndDate())
-                .keyword(createRequestDto.getKeyword())
                 .experienceType(ExperienceType.valueOf(createRequestDto.getExperienceType()))
                 .situation(createRequestDto.getSituation())
                 .task(createRequestDto.getTask())
@@ -117,7 +118,6 @@ public class Experience extends BaseEntity {
                 .isEnded(createRequestDto.getEndDate().isBefore(LocalDate.now()))
                 .startDate(createRequestDto.getStartDate())
                 .endDate(createRequestDto.getEndDate())
-                .keyword(createRequestDto.getKeyword())
                 .experienceType(ExperienceType.valueOf(createRequestDto.getExperienceType()))
                 .situation(null)
                 .task(null)
@@ -160,7 +160,17 @@ public class Experience extends BaseEntity {
         this.isEnded = updateRequestDto.getEndDate().isBefore(LocalDate.now());
         this.startDate = updateRequestDto.getStartDate();
         this.endDate = updateRequestDto.getEndDate();
-        this.keyword = updateRequestDto.getKeyword();
+        this.keywords.clear();
+        this.keywords.addAll(updateRequestDto.getKeywords().stream()
+                .map(keywordStr -> Keyword.builder()
+                        .name(keywordStr)
+                        .experience(this)
+                        .build()).toList());
+
         this.experienceType = ExperienceType.valueOf(updateRequestDto.getExperienceType());
+    }
+
+    public void setKeyword(List<Keyword> keywords) {
+        this.keywords = keywords;
     }
 }

--- a/src/main/java/com/itstime/xpact/domain/experience/entity/Keyword.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/entity/Keyword.java
@@ -3,9 +3,13 @@ package com.itstime.xpact.domain.experience.entity;
 import com.itstime.xpact.domain.common.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+@Getter
 @Entity
+@Builder
 @Table(name = "keyword")
 @NoArgsConstructor
 @AllArgsConstructor
@@ -18,4 +22,8 @@ public class Keyword extends BaseEntity {
 
     @Column(name = "name")
     private String name;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "experience_id")
+    private Experience experience;
 }

--- a/src/main/java/com/itstime/xpact/domain/experience/entity/Keyword.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/entity/Keyword.java
@@ -1,0 +1,21 @@
+package com.itstime.xpact.domain.experience.entity;
+
+import com.itstime.xpact.domain.common.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "keyword")
+@NoArgsConstructor
+@AllArgsConstructor
+public class Keyword extends BaseEntity {
+
+    @Id
+    @Column(name = "keyword_id", nullable = false)
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+}

--- a/src/main/java/com/itstime/xpact/domain/experience/entity/Keyword.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/entity/Keyword.java
@@ -1,11 +1,15 @@
 package com.itstime.xpact.domain.experience.entity;
 
 import com.itstime.xpact.domain.common.BaseEntity;
+import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.List;
 
 @Getter
 @Entity
@@ -20,10 +24,22 @@ public class Keyword extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "name")
+    @Column(name = "name", length = 10, nullable = false)
     private String name;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "experience_id")
     private Experience experience;
+
+    public static void validateKeyword(List<String> keywords) {
+        if(keywords.size() > 5) {
+            throw CustomException.of(ErrorCode.KEYWORD_EXCEEDED);
+        }
+
+        keywords.forEach(keyword -> {
+            if(keyword.length() > 10) {
+                throw CustomException.of(ErrorCode.KEYWORD_TOO_LONG);
+            }
+        });
+    }
 }

--- a/src/main/java/com/itstime/xpact/domain/experience/service/ExperienceService.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/service/ExperienceService.java
@@ -8,6 +8,7 @@ import com.itstime.xpact.domain.experience.dto.request.ExperienceUpdateRequestDt
 import com.itstime.xpact.domain.experience.entity.*;
 import com.itstime.xpact.domain.experience.repository.ExperienceRepository;
 import com.itstime.xpact.domain.member.entity.Member;
+import com.itstime.xpact.domain.member.repository.MemberRepository;
 import com.itstime.xpact.domain.member.service.MemberService;
 import com.itstime.xpact.global.auth.SecurityProvider;
 import com.itstime.xpact.global.exception.CustomException;
@@ -17,6 +18,10 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 
 @Slf4j
@@ -28,23 +33,39 @@ public class ExperienceService {
     private final ExperienceRepository experienceRepository;
     private final SecurityProvider securityProvider;
     private final OpenAiService openAiService;
+    private final MemberRepository memberRepository;
 
     public void create(ExperienceCreateRequestDto createRequestDto) throws CustomException {
         // member 조회
-        Member member = securityProvider.getCurrentMember();
+        Member member = memberRepository.findById(securityProvider.getCurrentMemberId()).orElseThrow(() ->
+                CustomException.of(ErrorCode.MEMBER_NOT_EXISTS));
 
         // enum타입이 될 string 필드 검증 로직 (INVALID한 값이 들어오면 CustomException발생)
         Status.validateStatus(createRequestDto.getStatus());
         FormType.validateFormType(createRequestDto.getFormType());
         ExperienceType.validateExperienceType(createRequestDto.getExperienceType());
 
+        // 키워드 설정하지 않는 로직 (따로 keyword 설정 필요)
         Experience experience = switch (FormType.valueOf(createRequestDto.getFormType())) {
             case SIMPLE_FORM -> Experience.SimpleForm(createRequestDto);
             case STAR_FORM -> Experience.StarForm(createRequestDto);
         };
 
-        // member-entity간 설정
+        // keyword 개수 체크
+        Keyword.validateKeyword(createRequestDto.getKeywords());
+
+        // dto의 keywords를 keyword 엔티티로 변경
+        List<Keyword> keywords = createRequestDto.getKeywords().stream()
+                .map(keywordStr -> Keyword.builder()
+                        .name(keywordStr)
+                        .experience(experience)
+                        .build())
+                .collect(Collectors.toList());
+
+        // experience와의 연관관계 설정
+        experience.setKeyword(keywords);
         experience.addMember(member);
+
         experienceRepository.save(experience);
 
         if(Status.valueOf(createRequestDto.getStatus()).equals(Status.SAVE))
@@ -76,6 +97,8 @@ public class ExperienceService {
             case STAR_FORM -> experience.updateToStarForm(updateRequestDto);
             case SIMPLE_FORM -> experience.updateToSimpleForm(updateRequestDto);
         }
+
+        Keyword.validateKeyword(updateRequestDto.getKeywords());
 
         experienceRepository.save(experience);
 

--- a/src/main/java/com/itstime/xpact/domain/experience/service/QueryExperienceService.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/service/QueryExperienceService.java
@@ -24,6 +24,7 @@ public class QueryExperienceService {
 
     private final ExperienceRepository experienceRepository;
     private final SecurityProvider securityProvider;
+    private final MemberRepository memberRepository;
 
     private static final String LATEST = "LATEST";
     private static final String OLDEST = "OLDEST";
@@ -32,7 +33,8 @@ public class QueryExperienceService {
     public List<ThumbnailExperienceReadResponseDto> readAll(List<String> types, String order) throws CustomException {
 
         // member 조회
-        Member member = securityProvider.getCurrentMember();
+        Member member = memberRepository.findById(securityProvider.getCurrentMemberId()).orElseThrow(() ->
+                CustomException.of(ErrorCode.MEMBER_NOT_EXISTS));
 
         Sort sort;
         if(order.equals(LATEST)) {

--- a/src/main/java/com/itstime/xpact/global/exception/ErrorCode.java
+++ b/src/main/java/com/itstime/xpact/global/exception/ErrorCode.java
@@ -65,6 +65,10 @@ public enum ErrorCode {
     // recruit
     RECRUIT_NOT_FOUND(HttpStatus.BAD_REQUEST, "RE001", "해당 직무가 존재하지 않습니다."),
     EMPTY_DESIRED_RECRUIT(HttpStatus.BAD_REQUEST, "RE002", "희망 직무가 선택되지 않았습니다."),
+
+    // keyword
+    KEYWORD_EXCEEDED(HttpStatus.BAD_REQUEST, "EXP009", "키워드는 5개를 넘길 수 없습니다."),
+    KEYWORD_TOO_LONG(HttpStatus.BAD_REQUEST, "EXP010", "키워드는 10글자를 넘길 수 없습니다."),
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🔧 관련 이슈
- Closes #53 

## 📌 PR 유형
> 어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가

## 📝 작업 내용
- experience에 keyword 추가
- keyword를 experience의 필드로 처리할까 엔티티로 생성할까 고민하다가 experience에 이미 필드값이 많고 keyword의 개수가 가변적이므로 엔티티로 생성하기로 결정
- keyword는 최대 5개까지 가능하며, 하나의 키워드는 10글자를 넘을 수 없음


## api 예시
### 경험 생성 (POST /api/exp)
<img width="253" alt="스크린샷 2025-05-07 오전 10 47 50" src="https://github.com/user-attachments/assets/e006387c-54b5-4049-a6fe-09fbc4898de7" />

<img width="969" alt="스크린샷 2025-05-07 오전 10 49 05" src="https://github.com/user-attachments/assets/884d3949-15e5-4d28-9007-3aa48b3092ff" />
- 키워드 1, 2, 3, 4, 5개 저장


### 경험 수정 (PATCH /api/exp)
<img width="368" alt="스크린샷 2025-05-07 오전 10 49 41" src="https://github.com/user-attachments/assets/54895a8f-7c13-44bc-af74-497c77685bd1" />

<img width="970" alt="스크린샷 2025-05-07 오전 10 50 17" src="https://github.com/user-attachments/assets/414e0bcd-7fd9-43dc-9a0b-7c5247dd5eb0" />
- 키워드가 5, 6, 7,  8, 9로 수정


### 경험 조회 (GET /api/exp/{exp_id}
<img width="475" alt="스크린샷 2025-05-07 오전 10 50 53" src="https://github.com/user-attachments/assets/815b9110-2604-4a05-b8be-74f4c7672437" />

- 키워드 5, 6 ,7, 8, 9 조회 됨


### 키워드가 5개를 넘었을 때
<img width="426" alt="image" src="https://github.com/user-attachments/assets/717707e6-5db0-4331-a654-3a078dc70389" />


### 키워드가 10글자를 넘었을 때
<img width="350" alt="image" src="https://github.com/user-attachments/assets/dad74b73-e020-4ee1-84b3-494a7ea7717f" />



## ✏️ 기타
