### PR TITLE
Feature/#62/core skill map

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -79,6 +79,7 @@ dependencies {
 
     // jackson
     implementation 'com.fasterxml.jackson.core:jackson-core'
+    implementation 'com.fasterxml.jackson.core:jackson-databind'
 
     implementation 'org.seleniumhq.selenium:selenium-java:4.31.0'
 

--- a/src/main/java/com/itstime/xpact/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/controller/DashboardController.java
@@ -1,7 +1,7 @@
 package com.itstime.xpact.domain.dashboard.controller;
 
+import com.itstime.xpact.domain.dashboard.dto.response.MapResponseDto;
 import com.itstime.xpact.domain.dashboard.service.DashboardService;
-import com.itstime.xpact.domain.dashboard.service.ScoreResultStore;
 import com.itstime.xpact.global.exception.CustomException;
 import com.itstime.xpact.global.response.RestResponse;
 import lombok.RequiredArgsConstructor;
@@ -15,29 +15,27 @@ import org.springframework.web.bind.annotation.*;
 public class DashboardController {
 
     private final DashboardService dashboardService;
-    private final ScoreResultStore scoreResultStore;
 
-    // 점수 계산 환산 확인을 위한 Test Controller
-    // TODO : 추후에 수정 필요
     @PostMapping
-    public ResponseEntity<?> getScore(
+    public ResponseEntity<?> evaluateScoreAsync(
             @RequestHeader("Authorization") String token) throws CustomException {
-        dashboardService.coreSkillMap();
-        return ResponseEntity.accepted()
-                .body("Request Accepted.");
+
+        Long memberId = dashboardService.evaluateAsync();
+        return ResponseEntity.accepted().body("Request Accepted for memberId: " + memberId);
     }
 
-    @PostMapping("/{memberId}")
+    @GetMapping("/{memberId}")
     public ResponseEntity<?> getScoreResult(
             @RequestHeader("Authorization") String token,
             @PathVariable Long memberId) throws CustomException {
 
-        String result = scoreResultStore.get(memberId);
-        if (result == null) {
-            return ResponseEntity.status(HttpStatus.PROCESSING).body("Request Processing");
+        MapResponseDto response = dashboardService.getEvaluationResult(memberId)
+                .orElse(null);
+
+        if (response == null) {
+            return ResponseEntity.status(HttpStatus.ACCEPTED).body("Processing");
         }
-        return ResponseEntity.ok(
-                RestResponse.ok(result)
-        );
+
+        return ResponseEntity.ok(RestResponse.ok(response));
     }
 }

--- a/src/main/java/com/itstime/xpact/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/controller/DashboardController.java
@@ -16,7 +16,7 @@ public class DashboardController {
 
     private final DashboardService dashboardService;
 
-    @PostMapping
+    @PostMapping("/skills")
     public ResponseEntity<?> evaluateScoreAsync(
             @RequestHeader("Authorization") String token) throws CustomException {
 
@@ -24,7 +24,7 @@ public class DashboardController {
         return ResponseEntity.accepted().body("Request Accepted for memberId: " + memberId);
     }
 
-    @GetMapping("/{memberId}")
+    @GetMapping("/skills/{memberId}")
     public ResponseEntity<?> getScoreResult(
             @RequestHeader("Authorization") String token,
             @PathVariable Long memberId) throws CustomException {

--- a/src/main/java/com/itstime/xpact/domain/dashboard/dto/response/MapResponseDto.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/dto/response/MapResponseDto.java
@@ -1,6 +1,7 @@
 package com.itstime.xpact.domain.dashboard.dto.response;
 
 import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 
@@ -9,6 +10,7 @@ import java.util.List;
 @Setter
 @AllArgsConstructor
 @RequiredArgsConstructor
+@Data
 public class MapResponseDto {
     private List<ScoreResponseDto> coreSkillMaps;
 

--- a/src/main/java/com/itstime/xpact/domain/dashboard/dto/response/MapResponseDto.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/dto/response/MapResponseDto.java
@@ -1,0 +1,15 @@
+package com.itstime.xpact.domain.dashboard.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Setter
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class MapResponseDto {
+    private List<ScoreResponseDto> coreSkillMaps;
+
+}

--- a/src/main/java/com/itstime/xpact/domain/dashboard/dto/response/ScoreResponseDto.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/dto/response/ScoreResponseDto.java
@@ -1,0 +1,14 @@
+package com.itstime.xpact.domain.dashboard.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+@AllArgsConstructor
+public class ScoreResponseDto {
+
+    private String coreSkillName;
+    private double score;
+}

--- a/src/main/java/com/itstime/xpact/domain/dashboard/dto/response/ScoreResponseDto.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/dto/response/ScoreResponseDto.java
@@ -1,12 +1,14 @@
 package com.itstime.xpact.domain.dashboard.dto.response;
 
 import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Getter
 @AllArgsConstructor
+@Data
 public class ScoreResponseDto {
 
     private String coreSkillName;

--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/DashboardService.java
@@ -1,8 +1,12 @@
 package com.itstime.xpact.domain.dashboard.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.itstime.xpact.domain.dashboard.dto.response.MapResponseDto;
+import com.itstime.xpact.domain.dashboard.dto.response.ScoreResponseDto;
 import com.itstime.xpact.domain.experience.repository.ExperienceRepository;
 import com.itstime.xpact.domain.member.entity.Member;
-import com.itstime.xpact.domain.member.repository.MemberRepository;
 import com.itstime.xpact.domain.recruit.entity.CoreSkill;
 import com.itstime.xpact.domain.recruit.entity.DetailRecruit;
 import com.itstime.xpact.domain.recruit.repository.DetailRecruitRepository;
@@ -16,6 +20,8 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
@@ -27,19 +33,27 @@ public class DashboardService {
     private final OpenAiService openAiService;
     private final SecurityProvider securityProvider;
     private final ScoreResultStore scoreResultStore;
+    private final ObjectMapper objectMapper;
 
-    private final MemberRepository memberRepository;
     private final DetailRecruitRepository detailRecruitRepository;
     private final ExperienceRepository experienceRepository;
 
 
     @Transactional(readOnly = true)
-    public CompletableFuture<String> coreSkillMap() throws CustomException {
+    public Long evaluateAsync() throws CustomException {
+        Member member = securityProvider.getCurrentMember();
 
-        Long memberId = securityProvider.getCurrentMemberId();
-        log.info("{} 회원 조회 시작...", memberId);
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> CustomException.of(ErrorCode.MEMBER_NOT_EXISTS));
+        CompletableFuture.runAsync(() -> {
+            try {
+                performEvaluation(member);
+            } catch (CustomException e) {
+                log.error("Request Not Accepted.", e.getMessage());
+            }
+        });
+        return member.getId();
+    }
+
+    private void performEvaluation(Member member) throws CustomException {
 
         String desiredRecruit = member.getDesiredRecruit();
         log.info("{} DetailRecruit 조회 시작...", desiredRecruit);
@@ -50,14 +64,41 @@ public class DashboardService {
         CoreSkill coreSkill = detailRecruitRepository.findCoreSkillById(detailRecruit.getId())
                 .orElseThrow(() -> CustomException.of(ErrorCode.NOT_FOUND_CORESKILLS));
 
-        String experiences = experienceRepository.findSummaryByMemberId(memberId).stream()
+        String experiences = experienceRepository.findSummaryByMemberId(member.getId()).stream()
                 .collect(Collectors.joining("\n"));
 
         List<String> coreSkillList = coreSkill.getCoreSKills();
-        return openAiService.evaluateScore(experiences, coreSkillList)
-                .thenApply(result -> {
-                    scoreResultStore.save(memberId, result);
-                    return result;
+
+        openAiService.evaluateScore(experiences, coreSkillList)
+                .thenApply(this::toMapDto)
+                .thenAccept(resultDto -> {
+                    try {
+                        scoreResultStore.save(member.getId(), resultDto.toString());
+                    } catch (Exception e) {
+                        log.error("결과를 저장하는 것에 실패하였습니다.", e);
+                    }
                 });
+    }
+
+    public Optional<MapResponseDto> getEvaluationResult(Long memberId) {
+        return Optional.of(toMapDto(scoreResultStore.get(memberId)));
+    }
+
+    // 점수를 DTO로 매핑
+    private MapResponseDto toMapDto(String result) {
+
+        try {
+            Map<String, Double> maps = objectMapper.readValue(result, new TypeReference<>() {});
+
+            List<ScoreResponseDto> scores = maps.entrySet()
+                    .stream()
+                    .map(entry -> new ScoreResponseDto(entry.getKey(), entry.getValue()))
+                    .collect(Collectors.toList());
+
+            return new MapResponseDto(scores);
+        } catch (JsonProcessingException e) {
+            log.error("OpenAI 응답 중 오류... {}", result, e);
+            throw CustomException.of(ErrorCode.UNMATCHED_OPENAI_FORMAT);
+        }
     }
 }

--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/ScoreResultStore.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/ScoreResultStore.java
@@ -11,12 +11,12 @@ public class ScoreResultStore {
     private final RedisTemplate<String, String> redisTemplate;
 
     public void save(Long memberId, String result) {
-        String key = "memberId:" + memberId;
+        String key = "coreSkillMap:" + memberId;
         redisTemplate.opsForValue().set(key, result);
     }
 
     public String get(Long memberId) {
-        String key = "memberId:" + memberId;
+        String key = "coreSkillMap:" + memberId;
         return (String) redisTemplate.opsForValue().get(key);
     }
 }

--- a/src/main/java/com/itstime/xpact/global/exception/ErrorCode.java
+++ b/src/main/java/com/itstime/xpact/global/exception/ErrorCode.java
@@ -56,6 +56,7 @@ public enum ErrorCode {
     OPENAI_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "OPENAI001", "OpenAI Error"),
     FAILED_OPENAI_PARSING(HttpStatus.BAD_REQUEST, "OPENAI002", "OpenAI의 응답을 파싱할 수 없습니다."),
     FILE_NOT_FOUND(HttpStatus.BAD_REQUEST, "OPENAI003", "업로드할 파일이 존재하지 않습니다."),
+    UNMATCHED_OPENAI_FORMAT(HttpStatus.BAD_REQUEST, "OPENAI004", "OpenAI 응답이 형식에 맞지 않습니다."),
 
     // crawling
     CRAWLING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "CRAWL001", "Crawling Error"),
@@ -75,6 +76,9 @@ public enum ErrorCode {
     // coreSkill
     NOT_FOUND_CORESKILLS(HttpStatus.BAD_REQUEST, "CSE001", "해당 핵심 역량을 불러오는 데에 실패했습니다."),
     DETAILRECRUIT_NOT_FOUND(HttpStatus.BAD_REQUEST, "CSE003", "찾을 수 없습니다."),
+
+    // skill map
+    UNLOADED_SKILL_MAP(HttpStatus.BAD_REQUEST, "SME001", "핵심 스킬맵 로드에 실패하였습니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/itstime/xpact/global/openai/OpenAiService.java
+++ b/src/main/java/com/itstime/xpact/global/openai/OpenAiService.java
@@ -1,5 +1,6 @@
 package com.itstime.xpact.global.openai;
 
+import com.itstime.xpact.domain.dashboard.dto.response.MapResponseDto;
 import com.itstime.xpact.domain.experience.entity.Experience;
 import org.springframework.scheduling.annotation.Async;
 
@@ -15,5 +16,5 @@ public interface OpenAiService {
     Map<String, Map<String, String>> getCoreSkill(List<String> recruitNames);
 
     @Async
-    CompletableFuture<String> evaluateScore(String experiences, List<String> coreSkills);
+    CompletableFuture<MapResponseDto> evaluateScore(String experiences, List<String> coreSkills);
 }

--- a/src/main/java/com/itstime/xpact/global/openai/OpenAiServiceImpl.java
+++ b/src/main/java/com/itstime/xpact/global/openai/OpenAiServiceImpl.java
@@ -104,8 +104,17 @@ public class OpenAiServiceImpl implements OpenAiService {
         Message userMessage = new UserMessage(message);
         Message systemMessage = new SystemMessage(buildSystemInstruction(coreSkills));
 
-        String response = openAiChatModel.call(userMessage, systemMessage);
-        return CompletableFuture.completedFuture(response);
+        // JSON 파싱
+        String rawResponse = openAiChatModel.call(systemMessage, userMessage);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            MapResponseDto result = objectMapper.readValue(rawResponse, MapResponseDto.class);
+            return CompletableFuture.completedFuture(result);
+        } catch (JsonProcessingException e) {
+            log.error("readValue 불가...", e);
+            throw CustomException.of(ErrorCode.FAILED_OPENAI_PARSING);
+        }
     }
 
     private String buildSystemInstruction(List<String> coreSkills) {

--- a/src/main/java/com/itstime/xpact/global/openai/OpenAiServiceImpl.java
+++ b/src/main/java/com/itstime/xpact/global/openai/OpenAiServiceImpl.java
@@ -105,7 +105,7 @@ public class OpenAiServiceImpl implements OpenAiService {
 
     private String buildSystemInstruction(List<String> coreSkills) {
         StringBuilder builder = new StringBuilder();
-        builder.append("Explain Korean. Follow the format below.\n{\n");
+        builder.append("Explain Korean. Follow the JSON format below.\n{\n");
         for (String coreSkill : coreSkills) {
             builder.append(coreSkill).append(": {score},\n");
         }

--- a/src/main/java/com/itstime/xpact/global/openai/OpenAiServiceImpl.java
+++ b/src/main/java/com/itstime/xpact/global/openai/OpenAiServiceImpl.java
@@ -1,9 +1,13 @@
 package com.itstime.xpact.global.openai;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.itstime.xpact.domain.dashboard.dto.response.MapResponseDto;
 import com.itstime.xpact.domain.experience.entity.Experience;
 import com.itstime.xpact.domain.recruit.entity.DetailRecruit;
 import com.itstime.xpact.domain.recruit.repository.DetailRecruitRepository;
 import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.ai.chat.messages.Message;
@@ -11,10 +15,11 @@ import org.springframework.ai.chat.messages.SystemMessage;
 import org.springframework.ai.chat.messages.UserMessage;
 import org.springframework.ai.chat.model.ChatResponse;
 import org.springframework.ai.chat.prompt.Prompt;
-import org.springframework.ai.chat.prompt.PromptTemplate;
+import org.springframework.ai.chat.prompt.PromptTemplate;;
 import org.springframework.ai.openai.OpenAiChatModel;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
+
 
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
@@ -86,7 +91,7 @@ public class OpenAiServiceImpl implements OpenAiService {
     }
 
     @Async
-    public CompletableFuture<String> evaluateScore(String experiences, List<String> coreSkills) throws CustomException {
+    public CompletableFuture<MapResponseDto> evaluateScore(String experiences, List<String> coreSkills) throws CustomException {
 
         OpenAiRequestBuilder builder = new OpenAiRequestBuilder();
 
@@ -106,9 +111,12 @@ public class OpenAiServiceImpl implements OpenAiService {
     private String buildSystemInstruction(List<String> coreSkills) {
         StringBuilder builder = new StringBuilder();
         builder.append("Explain Korean. Follow the JSON format below.\n{\n");
+        builder.append("\"coreSkillMaps\": [\n{");
         for (String coreSkill : coreSkills) {
-            builder.append(coreSkill).append(": {score},\n");
+            builder.append("\"coreSkillName\": ").append(coreSkill).append(", ");
+            builder.append("\"score\": float between 0.0~10.0 },\n");
         }
+        builder.append("]\n");
         builder.append("}");
         return builder.toString();
     }


### PR DESCRIPTION
## 🔧 관련 이슈
- closed #62 

## 📌 PR 유형
> 어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## 📝 작업 내용
- 프론트에서 StarGraph의 형식으로 작업하기위하여 다음과 같은 형식으로 DTO를 중첩하여 응답 매핑
```json
{
  "coreSkillMaps": [
    { "coreSkillName": "커뮤니케이션", "score": 8.5 },
    { "coreSkillName": "문제 해결력", "score": 9.0 },
    { "coreSkillName": "사용자 중심 사고", "score": 9.0 },
    { "coreSkillName": "콘텐츠 기획력", "score": 8.5 },
    { "coreSkillName": "데이터 분석", "score": 9.5 },
  ]
}
```
- ScoreResponseDto : coreSkillName에는 기준이 되는 핵심 역량 이름 들어감, score에는 그 역량에 맞는 점수
```java
public class ScoreResponseDto {
    private String coreSkillName;
    private double score;
}
```
- MapResponseDto : ScoreResponseDto 5개가 List형식으로 모여진 형식
```java
public class MapResponseDto {
    private List<ScoreResponseDto> coreSkillMaps;
}
```

- OpenAI의 프롬프트에 예시 양식을 구체적으로 추가함으로써 Json 형식을 모방한 String을 응답으로 설정 -> 해당 응답에 대하여 ObjectMapper를 통하여 MapResponseDto에 맞게 파싱하도록 설정
- 만약에 파싱하지 못할 경우, JsonProcessingException으로 예외 처리

- 핵심 스킬맵에 대하여 대시보드 반환 요청 API
![image](https://github.com/user-attachments/assets/06990255-2c2a-4254-9d32-0fe2f99e12ea)

- 응답 내용 확인을 위하여 해당 memberId를 path에 넣어 확인
<br>
-> 응답 처리가 완료되면, 다음과 같이 StarGraph에 맞는 양식으로 출력됨<br>

![image](https://github.com/user-attachments/assets/e424161e-3916-44f8-bf39-a5ac9fa4545b)
<br>
-> 만약 응답 처리 아직 진행 중이라면, HttpStatus.PROCESSING 값 반환

- Redis 서버에는 Dto를 다시 String으로 반환한 것 저장됨 확인 가능
![image](https://github.com/user-attachments/assets/517cfd74-ec04-45f5-a96a-dec2e78fcad5)


## ✏️ 기타
- StructuredOutput 을 이용한 Json 처리를 하고 싶었으나 import 불가능 문제로 인해 실패
- 보다 더 유지보수 및 확장성 있는 방법을 찾으면 좋을 것 같음