### PR TITLE
Feature/#84/dashboard history

### DIFF
--- a/src/main/java/com/itstime/xpact/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/controller/DashboardController.java
@@ -1,5 +1,6 @@
 package com.itstime.xpact.domain.dashboard.controller;
 
+import com.itstime.xpact.domain.dashboard.dto.response.HistoryResponseDto;
 import com.itstime.xpact.domain.dashboard.dto.response.MapResponseDto;
 import com.itstime.xpact.domain.dashboard.dto.response.RatioResponseDto;
 import com.itstime.xpact.domain.dashboard.service.DashboardService;
@@ -80,5 +81,18 @@ public class DashboardController {
     public ResponseEntity<RestResponse<?>> refresh() {
         dashboardService.refreshData();
         return ResponseEntity.ok(RestResponse.ok());
+    }
+
+    @Operation(summary = " 경험 히스토리 반환 API", description = """
+            사용자의 경험 생성 히스토리를 조회합니다.
+            """)
+    @ApiResponse(responseCode = "200", description = "응답 반환 성공",
+            content = @Content(schema = @Schema(implementation = RatioResponseDto.class)))
+    @GetMapping("/history")
+    public ResponseEntity<RestResponse<HistoryResponseDto>> getHistory(
+            @RequestParam("year") int year,
+            @RequestParam("month") int month) {
+        HistoryResponseDto dto = dashboardService.getCountPerDay(year, month);
+        return ResponseEntity.ok(RestResponse.ok(dto));
     }
 }

--- a/src/main/java/com/itstime/xpact/domain/dashboard/dto/response/HistoryResponseDto.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/dto/response/HistoryResponseDto.java
@@ -1,0 +1,33 @@
+package com.itstime.xpact.domain.dashboard.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class HistoryResponseDto {
+
+    private List<DateCount> dateCounts;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class DateCount {
+        private String date;
+        private int count;
+    }
+
+    public static HistoryResponseDto of(List<DateCount> dateCounts) {
+        return HistoryResponseDto.builder()
+                .dateCounts(dateCounts)
+                .build();
+    }
+}

--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/DashboardService.java
@@ -2,6 +2,7 @@ package com.itstime.xpact.domain.dashboard.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.itstime.xpact.domain.dashboard.dto.response.HistoryResponseDto;
 import com.itstime.xpact.domain.dashboard.dto.response.MapResponseDto;
 import com.itstime.xpact.domain.dashboard.dto.response.RatioResponseDto;
 import com.itstime.xpact.domain.dashboard.entity.RecruitCount;
@@ -209,5 +210,22 @@ public class DashboardService {
         experiences.stream()
                 .filter(e -> e.getDetailRecruit() == null)
                 .forEach(openAiService::getDetailRecruitFromExperience);
+    }
+
+    public HistoryResponseDto getCountPerDay(int year, int month) {
+        validateDate(year, month);
+        List<HistoryResponseDto.DateCount> results = experienceRepository.countByDay(year, month).stream()
+                .map(object ->
+                    HistoryResponseDto.DateCount.builder()
+                            .date(object[0].toString())
+                            .count(Integer.parseInt(object[1].toString()))
+                            .build())
+                .toList();
+
+        return HistoryResponseDto.of(results);
+    }
+
+    private void validateDate(int year, int month) {
+        if(year < 1 || month < 1 || month > 12) throw CustomException.of(ErrorCode.INVALID_DATE);
     }
 }

--- a/src/main/java/com/itstime/xpact/domain/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/repository/ExperienceRepository.java
@@ -1,7 +1,10 @@
 package com.itstime.xpact.domain.experience.repository;
 
+import com.google.common.collect.FluentIterable;
+import com.itstime.xpact.domain.dashboard.dto.response.HistoryResponseDto;
 import com.itstime.xpact.domain.experience.entity.Experience;
 import com.itstime.xpact.domain.member.entity.Member;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -9,6 +12,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Objects;
 
 @Repository
 public interface ExperienceRepository extends JpaRepository<Experience, Long>, ExperienceCustomRepository {
@@ -21,4 +25,9 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long>, E
     @Query("SELECT e FROM Experience e JOIN FETCH e.keywords WHERE e.member.id = :memberId")
     List<Experience> findAllWithKeywordByMemberId(@Param("memberId") Long memberId);
 
+    @Query("SELECT FUNCTION('DATE_FORMAT', e.createdTime, '%Y-%m-%d') AS DATE, count(*) " +
+            "FROM Experience e " +
+            "WHERE YEAR(e.createdTime) = :year AND MONTH(e.createdTime) = :month " +
+            "GROUP BY DATE ")
+    List<Object[]> countByDay(@Param("year") int year, @Param("month") int month);
 }

--- a/src/main/java/com/itstime/xpact/global/exception/ErrorCode.java
+++ b/src/main/java/com/itstime/xpact/global/exception/ErrorCode.java
@@ -82,6 +82,10 @@ public enum ErrorCode {
 
     // skill map
     UNLOADED_SKILL_MAP(HttpStatus.BAD_REQUEST, "SME001", "핵심 스킬맵 로드에 실패하였습니다."),
+
+    // etc
+    INVALID_DATE(HttpStatus.BAD_REQUEST, "ETC001", "잘못된 날짜입니다."),
+
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
## 🔧 관련 이슈
- closed #84 

## 📌 PR 유형
- [x] 새로운 기능 추가

## 📝 작업 내용
- 경험 히스토리 API 추가
- 날짜 별 경험 생성 횟수 반환
- 월별로 조회 가능

## ✏️ 호출 예시
<img width="520" alt="image" src="https://github.com/user-attachments/assets/79eb3753-8b52-46f5-a894-183dd7929134" />

- year=2025, month=5의 파라미터로 날짜 별 경험 생성 횟수 반환
- 경험을 생성하지 않은 날짜라면 반환 X