### PR TITLE
Feature/#87/dashboard timeline

### DIFF
--- a/src/main/java/com/itstime/xpact/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/controller/DashboardController.java
@@ -2,10 +2,12 @@ package com.itstime.xpact.domain.dashboard.controller;
 
 import com.itstime.xpact.domain.dashboard.dto.response.MapResponseDto;
 import com.itstime.xpact.domain.dashboard.dto.response.RatioResponseDto;
+import com.itstime.xpact.domain.dashboard.dto.response.TimelineResponseDto;
 import com.itstime.xpact.domain.dashboard.service.DashboardService;
 import com.itstime.xpact.global.exception.CustomException;
 import com.itstime.xpact.global.response.RestResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -14,6 +16,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RestController
 @RequiredArgsConstructor
@@ -80,5 +84,33 @@ public class DashboardController {
     public ResponseEntity<RestResponse<?>> refresh() {
         dashboardService.refreshData();
         return ResponseEntity.ok(RestResponse.ok());
+    }
+
+    @Operation(summary = "타임라인 조회 API",
+    description = """
+            경험에 대한 타임라인 조회를 위한 API입니다.<br>
+            조회할 기간의 시작날짜와 종료날짜를 입력해주세요.
+            """)
+    @ApiResponse(responseCode = "200", description = "타임라인 조회 성공",
+    content = @Content(schema = @Schema(implementation = TimelineResponseDto.class)))
+    @GetMapping("/timeline")
+    public ResponseEntity<RestResponse<?>> getTimeline(
+            @Parameter(
+                    description = "조회 기간 시작 날짜 (yyyy-MM-dd)",
+                    required = true,
+                    example = "2025-03-01"
+            )
+            @RequestParam("startLine") LocalDate startLine,
+            @Parameter(
+                    description = "조회 기간 종료 날짜 (yyyy-MM-dd)",
+                    required = true,
+                    example = "2025-07-31"
+            )
+            @RequestParam("endLine") LocalDate endLine
+            ) {
+        return ResponseEntity.ok(
+                RestResponse.ok(dashboardService.getTimeline(startLine, endLine)
+                )
+        );
     }
 }

--- a/src/main/java/com/itstime/xpact/domain/dashboard/dto/response/TimelineResponseDto.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/dto/response/TimelineResponseDto.java
@@ -1,0 +1,28 @@
+package com.itstime.xpact.domain.dashboard.dto.response;
+
+import com.itstime.xpact.domain.experience.common.ExperienceType;
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+@Schema(description = "경험에 대한 타임라인 조회 응답 DTO")
+public record TimelineResponseDto (
+        @Schema(description = "경험 시작 날짜",
+        example = "2025-03-20")
+        LocalDate startDate,
+        @Schema(description = "경험 종료 날짜",
+        example = "2025-07-12")
+        LocalDate endDate,
+        @Schema(description = "경험 제목",
+        example = "IT 연합 동아리 ITTA")
+        String title,
+        @Schema(description = "경험 유형",
+                example = "EXTERNAL_ACTIVITIES",
+                allowableValues = {"INTERN", "EXTERNAL_ACTIVITIES", "CONTEST",
+                        "PROJECT", "CERTIFICATES", "ACADEMIC_CLUB", "EDUCATION",
+                        "PRIZE", "VOLUNTEER_WORK", "STUDY_ABROAD", "ETC"})
+        ExperienceType experienceType
+        ) {
+}

--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/DashboardService.java
@@ -4,11 +4,13 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.itstime.xpact.domain.dashboard.dto.response.MapResponseDto;
 import com.itstime.xpact.domain.dashboard.dto.response.RatioResponseDto;
+import com.itstime.xpact.domain.dashboard.dto.response.TimelineResponseDto;
 import com.itstime.xpact.domain.dashboard.entity.RecruitCount;
 import com.itstime.xpact.domain.dashboard.repository.RecruitCountRepository;
 import com.itstime.xpact.domain.experience.entity.Experience;
 import com.itstime.xpact.domain.experience.repository.ExperienceRepository;
 import com.itstime.xpact.domain.member.entity.Member;
+import com.itstime.xpact.domain.member.repository.MemberRepository;
 import com.itstime.xpact.domain.recruit.entity.CoreSkill;
 import com.itstime.xpact.domain.recruit.entity.DetailRecruit;
 import com.itstime.xpact.domain.recruit.repository.DetailRecruitRepository;
@@ -21,6 +23,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import java.util.*;
@@ -41,6 +44,7 @@ public class DashboardService {
     private final DetailRecruitRepository detailRecruitRepository;
     private final ExperienceRepository experienceRepository;
     private final RecruitCountRepository recruitCountRepository;
+    private final MemberRepository memberRepository;
 
     @Transactional(readOnly = true)
     public Long evaluateAsync() throws CustomException {
@@ -209,5 +213,30 @@ public class DashboardService {
         experiences.stream()
                 .filter(e -> e.getDetailRecruit() == null)
                 .forEach(openAiService::getDetailRecruitFromExperience);
+    }
+
+    @Transactional(readOnly = true)
+    public List<TimelineResponseDto> getTimeline(
+            LocalDate startLine, LocalDate endLine) {
+
+        Long memberId = securityProvider.getCurrentMemberId();
+
+        // Fetch Join을 통한 LazyInitializationException 방지
+        Member member = memberRepository.findByIdWithExperiences(memberId)
+                .orElseThrow(() -> CustomException.of(ErrorCode.MEMBER_NOT_EXISTS));
+
+        return member.getExperiences().stream()
+                .filter(experience ->
+                {
+                    LocalDate expStart = experience.getStartDate();
+                    LocalDate expEnd = experience.getEndDate();
+
+                    if (expStart == null) return false; // 시작일자 없는 것은 제외
+
+                    return (expEnd == null || !expEnd.isBefore(startLine)) && (!expStart.isAfter(endLine) && (expStart.isAfter(startLine)));
+                })
+                .sorted(Comparator.comparing(Experience::getStartDate))
+                .map(Experience::toTimeLineDto)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/itstime/xpact/domain/experience/entity/Experience.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/entity/Experience.java
@@ -1,6 +1,7 @@
 package com.itstime.xpact.domain.experience.entity;
 
 import com.itstime.xpact.domain.common.BaseEntity;
+import com.itstime.xpact.domain.dashboard.dto.response.TimelineResponseDto;
 import com.itstime.xpact.domain.experience.common.ExperienceType;
 import com.itstime.xpact.domain.experience.common.FormType;
 import com.itstime.xpact.domain.experience.common.Status;
@@ -10,12 +11,10 @@ import com.itstime.xpact.domain.member.entity.Member;
 import com.itstime.xpact.domain.recruit.entity.DetailRecruit;
 import jakarta.persistence.*;
 import lombok.*;
-import lombok.experimental.SuperBuilder;
 
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Getter
 @Entity
@@ -172,5 +171,15 @@ public class Experience extends BaseEntity {
 
     public void setKeyword(List<Keyword> keywords) {
         this.keywords = keywords;
+    }
+
+
+    public static TimelineResponseDto toTimeLineDto(Experience experience) {
+            return TimelineResponseDto.builder()
+                    .startDate(experience.getStartDate())
+                    .endDate(experience.getEndDate())
+                    .title(experience.getTitle())
+                    .experienceType(experience.getExperienceType())
+                    .build();
     }
 }

--- a/src/main/java/com/itstime/xpact/domain/member/repository/MemberRepository.java
+++ b/src/main/java/com/itstime/xpact/domain/member/repository/MemberRepository.java
@@ -2,6 +2,8 @@ package com.itstime.xpact.domain.member.repository;
 
 import com.itstime.xpact.domain.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -11,4 +13,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     boolean existsByEmail(String email);
     Optional<Member> findByEmail(String email);
+
+    @Query("SELECT m FROM Member m JOIN FETCH m.experiences WHERE m.id = :id")
+    Optional<Member> findByIdWithExperiences(@Param("id") Long memberId);
 }


### PR DESCRIPTION
## 🔧 관련 이슈
- closed #87 

## 📌 PR 유형
> 어떤 변경 사항이 있나요?
- [x] 새로운 기능 추가

## 📝 작업 내용
- GET 요청을 통해 RequestParameter의 기한 내의 경험들에 대하여 반환하도록 설정
- 경험의 시작일을 기준으로 반환되도록 설정
![image](https://github.com/user-attachments/assets/4a5644cb-ae17-4dd4-83f4-886483030164)
<img src="https://github.com/user-attachments/assets/c42b4430-4423-4663-99f3-1802d624da1a" width="60%">


## ✏️ 기타
- LazyInitializationException 때문에 FETCH JOIN을 포함한 MemberRepository 의존성을 추가
- DashboardService 로직에 너무 많은 컴포넌트 주입이 이뤄지고있어 좀더 나은 구조 고려해보면 좋을 것 같습니다 👨‍🎤 