### PR TITLE
Fix/#96/security provider

### DIFF
--- a/src/main/java/com/itstime/xpact/domain/experience/service/ExperienceService.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/service/ExperienceService.java
@@ -81,7 +81,7 @@ public class ExperienceService {
                 .collect(Collectors.toCollection(ArrayList::new));
         experience.setKeywords(keywords);
 
-        if(Experience.isNeedFiles(createRequestDto.getExperienceType())) {
+        if(Experience.isNeedFiles(createRequestDto.getExperienceType()) && createRequestDto.getFiles() != null) {
             List<File> files = createRequestDto.getFiles().stream()
                     .map(fileUrl -> File.builder()
                             .fileUrl(fileUrl)

--- a/src/main/java/com/itstime/xpact/domain/experience/service/ExperienceService.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/service/ExperienceService.java
@@ -34,12 +34,10 @@ public class ExperienceService {
     private final ExperienceRepository experienceRepository;
     private final SecurityProvider securityProvider;
     private final OpenAiService openAiService;
-    private final MemberRepository memberRepository;
 
     public void create(ExperienceCreateRequestDto createRequestDto) throws CustomException {
         // member 조회
-        Member member = memberRepository.findById(securityProvider.getCurrentMemberId()).orElseThrow(() ->
-                CustomException.of(ErrorCode.MEMBER_NOT_EXISTS));
+        Member member = securityProvider.getCurrentMember();
 
         // enum타입이 될 string 필드 검증 로직 (INVALID한 값이 들어오면 CustomException발생)
         Status.validateStatus(createRequestDto.getStatus());
@@ -171,7 +169,7 @@ public class ExperienceService {
     }
 
     public void deleteAll() {
-        Member member = memberRepository.findById(securityProvider.getCurrentMemberId()).orElseThrow();
+        Member member = securityProvider.getCurrentMember();
         experienceRepository.deleteAllByMember(member);
     }
 }

--- a/src/main/java/com/itstime/xpact/domain/experience/service/ExperienceService.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/service/ExperienceService.java
@@ -8,7 +8,6 @@ import com.itstime.xpact.domain.experience.dto.request.ExperienceUpdateRequestDt
 import com.itstime.xpact.domain.experience.entity.*;
 import com.itstime.xpact.domain.experience.repository.ExperienceRepository;
 import com.itstime.xpact.domain.member.entity.Member;
-import com.itstime.xpact.domain.member.repository.MemberRepository;
 import com.itstime.xpact.global.auth.SecurityProvider;
 import com.itstime.xpact.global.exception.CustomException;
 import com.itstime.xpact.global.exception.ErrorCode;

--- a/src/main/java/com/itstime/xpact/domain/member/service/MemberService.java
+++ b/src/main/java/com/itstime/xpact/domain/member/service/MemberService.java
@@ -5,12 +5,9 @@ import com.itstime.xpact.domain.member.dto.response.EducationSaveResponseDto;
 import com.itstime.xpact.domain.member.dto.response.MemberSaveResponseDto;
 import com.itstime.xpact.domain.member.dto.response.MypageInfoResponseDto;
 import com.itstime.xpact.domain.member.entity.Member;
-import com.itstime.xpact.domain.member.repository.MemberRepository;
 import com.itstime.xpact.domain.recruit.dto.response.DesiredRecruitResponseDto;
 import com.itstime.xpact.domain.recruit.service.RecruitService;
 import com.itstime.xpact.global.auth.SecurityProvider;
-import com.itstime.xpact.global.exception.CustomException;
-import com.itstime.xpact.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -21,7 +18,6 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class MemberService {
 
-    private final MemberRepository memberRepository;
     private final SecurityProvider securityProvider;
 
     private final EducationService educationService;
@@ -31,9 +27,7 @@ public class MemberService {
     @Transactional
     public MemberSaveResponseDto updateMember(MemberSaveRequestDto requestDto) {
 
-        Long memberId = securityProvider.getCurrentMemberId();
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> CustomException.of(ErrorCode.MEMBER_NOT_EXISTS));
+        Member member = securityProvider.getCurrentMember();
 
         member.updateMemberInfo(requestDto);
 
@@ -53,9 +47,7 @@ public class MemberService {
 
     public MypageInfoResponseDto getMember() {
 
-        Long memberId = securityProvider.getCurrentMemberId();
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> CustomException.of(ErrorCode.MEMBER_NOT_EXISTS));
+        Member member = securityProvider.getCurrentMember();
 
         log.info("{} : 회원의 정보 조회 시작 ... ", member.getEmail());
 

--- a/src/main/java/com/itstime/xpact/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/itstime/xpact/domain/recruit/service/RecruitService.java
@@ -1,7 +1,6 @@
 package com.itstime.xpact.domain.recruit.service;
 
 import com.itstime.xpact.domain.member.entity.Member;
-import com.itstime.xpact.domain.member.repository.MemberRepository;
 import com.itstime.xpact.domain.member.util.TrieUtil;
 import com.itstime.xpact.domain.recruit.dto.request.DesiredRecruitRequestDto;
 import com.itstime.xpact.domain.recruit.dto.response.DesiredRecruitResponseDto;

--- a/src/main/java/com/itstime/xpact/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/itstime/xpact/domain/recruit/service/RecruitService.java
@@ -31,7 +31,6 @@ public class RecruitService {
 
     private final RecruitRepository recruitRepository;
     private final DetailRecruitRepository detailRecruitRepository;
-    private final MemberRepository memberRepository;
 
 
     // 산업 전체 조회
@@ -84,11 +83,8 @@ public class RecruitService {
     @Transactional
     public DesiredRecruitResponseDto updateDesiredRecruit(DesiredRecruitRequestDto requestDto) throws CustomException {
 
-        Long memberId = securityProvider.getCurrentMemberId();
-
         // 실제 DB에서 영속 상태의 Member 조회
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_EXISTS));
+        Member member = securityProvider.getCurrentMember();
 
         if (requestDto.detailRecruitName() == null || requestDto.detailRecruitName().isBlank()) {
             throw new CustomException(ErrorCode.EMPTY_DESIRED_RECRUIT);

--- a/src/main/java/com/itstime/xpact/global/auth/SecurityProvider.java
+++ b/src/main/java/com/itstime/xpact/global/auth/SecurityProvider.java
@@ -1,21 +1,32 @@
 package com.itstime.xpact.global.auth;
 
 import com.itstime.xpact.domain.member.entity.Member;
+import com.itstime.xpact.domain.member.repository.MemberRepository;
 import com.itstime.xpact.global.exception.CustomException;
 import com.itstime.xpact.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Component;
 
 @Component
+@RequiredArgsConstructor
 public class SecurityProvider {
 
+    private final MemberRepository memberRepository;
+
+    // 인증된 MemberId 반환
     public Long getCurrentMemberId() {
-        return getCurrentMember().getId();
+        return getMemberFromSecurityContext().getId();
     }
 
     // 현재 인증된 Member를 반환
     public Member getCurrentMember() {
+        return memberRepository.findById(getMemberFromSecurityContext().getId()).orElseThrow(() ->
+                CustomException.of(ErrorCode.MEMBER_NOT_EXISTS));
+    }
+
+    private Member getMemberFromSecurityContext() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (!(authentication instanceof MemberAuthentication memberAuth)) {


### PR DESCRIPTION
## 🔧 관련 이슈
- closed #96 

## 📌 PR 유형
- [x] 코드 리팩토링

## 📝 작업 내용
- 기존의 SecurityProvider의 getCurrentMember()의 리턴 Member를 영속화하도록 설정했습니다.
- 또한, Member객체가 아닌, memberId가 필요한 로직이 존재했으므로 이를 위해 getCurrentMemberId()의 메서드도 남겨두었습니다.
- 이를 통해 Service레이어에서 해당 Member를 조회하지 않아도 사용할 수 있도록 하였습니다.
- 해당 리팩토링을 통해, `ExperienceService`, `RecruitService`, `MemberService`에서 `MemberRepository`를 의존하던 관계를 없앨 수 있었습니다.
