### PR TITLE
Fix/#104/fix history

### DIFF
--- a/src/main/java/com/itstime/xpact/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/controller/DashboardController.java
@@ -93,12 +93,24 @@ public class DashboardController {
     @ApiResponse(responseCode = "200", description = "응답 반환 성공",
             content = @Content(schema = @Schema(implementation = RatioResponseDto.class)))
     @GetMapping("/history")
+    public ResponseEntity<RestResponse<HistoryOldResponseDto>> getOldHistory(
+            @RequestParam("year") int year,
+            @RequestParam("month") int month) {
+        HistoryOldResponseDto dto = dashboardService.getOldExperienceHistory(year, month);
+        return ResponseEntity.ok(RestResponse.ok(dto));
+    }
+
+    @Operation(summary = "경험 히스토리 반환 API (new)", description = """
+            사용자의 경험 생성 히스토리를 3개월 단위로 조회합니다.
+            """)
+    @GetMapping("/history-new")
     public ResponseEntity<RestResponse<HistoryResponseDto>> getHistory(
             @RequestParam("year") int year,
             @RequestParam("month") int month) {
         HistoryResponseDto dto = dashboardService.getExperienceHistory(year, month);
         return ResponseEntity.ok(RestResponse.ok(dto));
     }
+
 
     @Operation(summary = "타임라인 조회 API",
     description = """

--- a/src/main/java/com/itstime/xpact/domain/dashboard/controller/HistoryOldResponseDto.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/controller/HistoryOldResponseDto.java
@@ -1,0 +1,32 @@
+package com.itstime.xpact.domain.dashboard.controller;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+
+@Getter
+@Builder
+@AllArgsConstructor
+@RequiredArgsConstructor
+public class HistoryOldResponseDto {
+
+    private List<DateCount> dateCounts;
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class DateCount {
+        private String date;
+        private int count;
+    }
+
+    public static HistoryOldResponseDto of(List<DateCount> dateCounts) {
+        return HistoryOldResponseDto.builder()
+                .dateCounts(dateCounts)
+                .build();
+    }
+}

--- a/src/main/java/com/itstime/xpact/domain/dashboard/dto/response/HistoryResponseDto.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/dto/response/HistoryResponseDto.java
@@ -5,9 +5,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
-import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 @Getter
 @Builder
@@ -15,7 +14,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class HistoryResponseDto {
 
-    private List<DateCount> dateCounts;
+    private Map<Integer, List<DateCount>> dateCounts;
 
     @Getter
     @Builder
@@ -25,9 +24,9 @@ public class HistoryResponseDto {
         private int count;
     }
 
-    public static HistoryResponseDto of(List<DateCount> dateCounts) {
+    public static HistoryResponseDto of(Map<Integer, List<DateCount>> groupByMonth) {
         return HistoryResponseDto.builder()
-                .dateCounts(dateCounts)
+                .dateCounts(groupByMonth)
                 .build();
     }
 }

--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/DashboardService.java
@@ -57,7 +57,8 @@ public class DashboardService {
 
     // 히스토리 조회
     public HistoryResponseDto getExperienceHistory(int year, int month) {
-        return timeService.getCountPerDay(year, month);
+        Member member = securityProvider.getCurrentMember();
+        return timeService.getCountPerDay(year, month, member);
     }
 
     // 타임라인 조회

--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/DashboardService.java
@@ -1,5 +1,6 @@
 package com.itstime.xpact.domain.dashboard.service;
 
+import com.itstime.xpact.domain.dashboard.controller.HistoryOldResponseDto;
 import com.itstime.xpact.domain.dashboard.dto.response.HistoryResponseDto;
 import com.itstime.xpact.domain.dashboard.dto.response.MapResponseDto;
 import com.itstime.xpact.domain.dashboard.dto.response.RatioResponseDto;
@@ -56,10 +57,16 @@ public class DashboardService {
     }
 
     // 히스토리 조회
+    public HistoryOldResponseDto getOldExperienceHistory(int year, int month) {
+        Member member = securityProvider.getCurrentMember();
+        return timeService.getOldCountPerDay(year, month, member);
+    }
+
     public HistoryResponseDto getExperienceHistory(int year, int month) {
         Member member = securityProvider.getCurrentMember();
         return timeService.getCountPerDay(year, month, member);
     }
+
 
     // 타임라인 조회
     @Transactional(readOnly = true)

--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/ratio/RatioService.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/ratio/RatioService.java
@@ -82,8 +82,8 @@ public class RatioService {
         List<Experience> experiences = experienceRepository.findAllWithDetailRecruitByMemberId(memberId);
         Map<String, Integer> result = new HashMap<>();
         experiences.forEach(e -> {
-            String detailRecruit = e.getDetailRecruit().getName();
-            if(detailRecruit != null) {
+            if(e.getDetailRecruit() != null) {
+                String detailRecruit = e.getDetailRecruit().getName();
                 result.put(detailRecruit, result.getOrDefault(detailRecruit, 0) + 1);
             }
         });

--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/time/TimeService.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/time/TimeService.java
@@ -58,9 +58,9 @@ public class TimeService {
                 .forEach(openAiService::getDetailRecruitFromExperience);
     }
 
-    public HistoryResponseDto getCountPerDay(int year, int month) {
+    public HistoryResponseDto getCountPerDay(int year, int month, Member member) {
         validateDate(year, month);
-        List<HistoryResponseDto.DateCount> results = experienceRepository.countByDay(year, month).stream()
+        List<HistoryResponseDto.DateCount> results = experienceRepository.countByDay(year, month, member).stream()
                 .map(object ->
                         HistoryResponseDto.DateCount.builder()
                                 .date(object[0].toString())

--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/time/TimeService.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/time/TimeService.java
@@ -1,5 +1,6 @@
 package com.itstime.xpact.domain.dashboard.service.time;
 
+import com.itstime.xpact.domain.dashboard.controller.HistoryOldResponseDto;
 import com.itstime.xpact.domain.dashboard.dto.response.HistoryResponseDto;
 import com.itstime.xpact.domain.dashboard.dto.response.TimelineResponseDto;
 import com.itstime.xpact.domain.experience.entity.Experience;
@@ -60,6 +61,22 @@ public class TimeService {
         experiences.stream()
                 .filter(e -> e.getDetailRecruit() == null)
                 .forEach(openAiService::getDetailRecruitFromExperience);
+    }
+
+    public HistoryOldResponseDto getOldCountPerDay(int year, int month, Member member) {
+        validateDate(year, month);
+        LocalDateTime startDate = LocalDateTime.of(year, month, 1, 0, 0, 0);
+        LocalDateTime endDate = LocalDateTime.of(year, month + 1, 1, 0, 0, 0);
+
+        List<HistoryOldResponseDto.DateCount> results = experienceRepository.countOldByDay(startDate, endDate, member).stream()
+                .map(object ->
+                        HistoryOldResponseDto.DateCount.builder()
+                                .date(object[0].toString())
+                                .count(Integer.parseInt(object[1].toString()))
+                                .build())
+                .toList();
+
+        return HistoryOldResponseDto.of(results);
     }
 
     public HistoryResponseDto getCountPerDay(int year, int month, Member member) {

--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/time/TimeService.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/time/TimeService.java
@@ -64,14 +64,14 @@ public class TimeService {
 
     public HistoryResponseDto getCountPerDay(int year, int month, Member member) {
         validateDate(year, month);
-
-        LocalDateTime startDate = LocalDateTime.of(year, month - 1, 1, 0, 0, 0);
-        LocalDateTime endDate = LocalDateTime.of(year, month + 2, 1, 0, 0, 0);
+        LocalDateTime now = LocalDateTime.of(year, month, 1, 0, 0, 0);
+        LocalDateTime startDate = now.withDayOfMonth(1).minusMonths(1);
+        LocalDateTime endDate = now.withDayOfMonth(1).plusMonths(2);
 
         // 현월일 때
         if(isNow(year, month)) {
-            startDate = LocalDateTime.of(year, month - 2, 1, 0, 0, 0);
-            endDate = LocalDateTime.of(year, month + 1, 1, 0, 0, 0);
+            startDate = now.withDayOfMonth(1).minusMonths(2);
+            endDate = now.withDayOfMonth(1).plusMonths(1);
         }
 
         List<HistoryResponseDto.DateCount> results = experienceRepository.countByDay(startDate, endDate, member).stream()

--- a/src/main/java/com/itstime/xpact/domain/experience/entity/Experience.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/entity/Experience.java
@@ -133,7 +133,7 @@ public class Experience extends BaseEntity {
                         .status(Status.valueOf(createRequestDto.getStatus()))
                         .formType(FormType.valueOf(createRequestDto.getFormType()))
                         .experienceType(ExperienceType.valueOf(createRequestDto.getExperienceType())).build())
-                .isEnded(createRequestDto.getEndDate().isBefore(LocalDate.now()))
+                .isEnded(createRequestDto.getIssueDate().isBefore(LocalDate.now()))
                 .startDate(createRequestDto.getStartDate())
                 .endDate(createRequestDto.getEndDate())
                 .title(null)

--- a/src/main/java/com/itstime/xpact/domain/experience/entity/Experience.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/entity/Experience.java
@@ -34,7 +34,7 @@ public class Experience extends BaseEntity {
     @Embedded // status, formType, ExperienceType 포함
     private MetaData metaData;
 
-    @Column(name = "title", nullable = false)
+    @Column(name = "title")
     private String title;
 
     @Embedded

--- a/src/main/java/com/itstime/xpact/domain/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/repository/ExperienceRepository.java
@@ -30,7 +30,15 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long>, E
             "FROM Experience e " +
             "WHERE e.createdTime >= :startDate AND e.createdTime < :endDate AND e.member = :member " +
             "GROUP BY DATE ")
+    List<Object[]> countOldByDay(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, Member member);
+
+    @Query("SELECT FUNCTION('DATE_FORMAT', e.createdTime, '%Y-%m-%d') AS DATE, count(*) " +
+            "FROM Experience e " +
+            "WHERE e.createdTime >= :startDate AND e.createdTime < :endDate AND e.member = :member " +
+            "GROUP BY DATE ")
     List<Object[]> countByDay(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, Member member);
 
     void deleteAllByMember(Member member);
+
+
 }

--- a/src/main/java/com/itstime/xpact/domain/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/repository/ExperienceRepository.java
@@ -1,10 +1,7 @@
 package com.itstime.xpact.domain.experience.repository;
 
-import com.google.common.collect.FluentIterable;
-import com.itstime.xpact.domain.dashboard.dto.response.HistoryResponseDto;
 import com.itstime.xpact.domain.experience.entity.Experience;
 import com.itstime.xpact.domain.member.entity.Member;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -13,7 +10,6 @@ import org.springframework.stereotype.Repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Objects;
 
 @Repository
 public interface ExperienceRepository extends JpaRepository<Experience, Long>, ExperienceCustomRepository {

--- a/src/main/java/com/itstime/xpact/domain/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/repository/ExperienceRepository.java
@@ -11,6 +11,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Objects;
 
@@ -27,9 +28,9 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long>, E
 
     @Query("SELECT FUNCTION('DATE_FORMAT', e.createdTime, '%Y-%m-%d') AS DATE, count(*) " +
             "FROM Experience e " +
-            "WHERE YEAR(e.createdTime) = :year AND MONTH(e.createdTime) = :month AND e.member = :member " +
+            "WHERE e.createdTime >= :startDate AND e.createdTime < :endDate AND e.member = :member " +
             "GROUP BY DATE ")
-    List<Object[]> countByDay(@Param("year") int year, @Param("month") int month, Member member);
+    List<Object[]> countByDay(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, Member member);
 
     void deleteAllByMember(Member member);
 }

--- a/src/main/java/com/itstime/xpact/domain/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/repository/ExperienceRepository.java
@@ -27,9 +27,9 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long>, E
 
     @Query("SELECT FUNCTION('DATE_FORMAT', e.createdTime, '%Y-%m-%d') AS DATE, count(*) " +
             "FROM Experience e " +
-            "WHERE YEAR(e.createdTime) = :year AND MONTH(e.createdTime) = :month " +
+            "WHERE YEAR(e.createdTime) = :year AND MONTH(e.createdTime) = :month AND e.member = :member " +
             "GROUP BY DATE ")
-    List<Object[]> countByDay(@Param("year") int year, @Param("month") int month);
+    List<Object[]> countByDay(@Param("year") int year, @Param("month") int month, Member member);
 
     void deleteAllByMember(Member member);
 }

--- a/src/main/java/com/itstime/xpact/domain/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/repository/ExperienceRepository.java
@@ -16,7 +16,7 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long>, E
 
     List<Experience> findAllByMember(Member member, Sort sort);
 
-    @Query("SELECT e FROM Experience e LEFT JOIN FETCH e.detailRecruit WHERE e.member.id = :memberId AND e.detailRecruit is not null ")
+    @Query("SELECT e FROM Experience e JOIN FETCH e.detailRecruit WHERE e.member.id = :memberId AND e.detailRecruit is not null ")
     List<Experience> findAllWithDetailRecruitByMemberId(@Param("memberId") Long memberId);
 
     @Query("SELECT e FROM Experience e JOIN FETCH e.keywords WHERE e.member.id = :memberId")

--- a/src/main/java/com/itstime/xpact/global/openai/OpenAiServiceImpl.java
+++ b/src/main/java/com/itstime/xpact/global/openai/OpenAiServiceImpl.java
@@ -41,7 +41,6 @@ public class OpenAiServiceImpl implements OpenAiService {
                 역할, 내가 한 일, 성과(결과)가 드러나도록 2줄 분량으로 요약해줘\s
                 요약만 출력되도록 해줘\s
                 data : %s""", experience.toString());
-        log.info(message);
 
         Prompt prompt = new Prompt(message);
         ChatResponse response = openAiChatModel.call(prompt);
@@ -137,8 +136,6 @@ public class OpenAiServiceImpl implements OpenAiService {
     public void getDetailRecruitFromExperience(Experience experience) {
         String experienceStr = experience.toString();
         String recruits = detailRecruitToString();
-        System.out.println("recruits = " + recruits);
-
         String message = String.format(
                 "다음 객체를 분석해서 주어진 recruit 중 가장 적절한 하나를 선택해 주세요.\n" +
                         "객체: %s\n" +


### PR DESCRIPTION
## 🔧 관련 이슈
- closed #104 

## 📌 PR 유형
- [x] 버그 수정

## 📝 작업 내용
- 대시보드 히스토리 API 추가 (`/api/dashboard/history-new`)
- experience의 `title`필드 nullable = false 설정
- 수상, 자격증 경험에서 endDate, title관련 NullPointerException 관련 로직 수정
- CreateExperienceRequestDto에서 getkeyword의 NullPointerException 관련 로직 수정

## ✏️ 기타
< 기존 히스토리 API>
<img width="471" alt="image" src="https://github.com/user-attachments/assets/e13efdfb-c18d-465c-a262-d56050249b81" />


<수정 히스토리 API>
<img width="513" alt="image" src="https://github.com/user-attachments/assets/0fd1bc84-0e93-4c80-bd1f-c28d96d69d99" />
