### PR TITLE
fix/#110 : experiences가 빈 값일 때 CustomException throw

### DIFF
--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/ratio/RatioService.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/ratio/RatioService.java
@@ -80,6 +80,11 @@ public class RatioService {
     private RecruitCount setCounts(Long memberId) {
 
         List<Experience> experiences = experienceRepository.findAllWithDetailRecruitByMemberId(memberId);
+
+        if(experiences == null || experiences.isEmpty()) {
+            throw CustomException.of(ErrorCode.EXPERIENCES_NOT_ENOUGH);
+        }
+
         Map<String, Integer> result = new HashMap<>();
         experiences.forEach(e -> {
             if(e.getDetailRecruit() != null) {
@@ -99,19 +104,17 @@ public class RatioService {
      */
     private void adjustRatio(Map<String, Double> result) {
         double diff = Math.round((100.0 - result.values().stream().mapToDouble(Double::doubleValue).sum()) * 10) / 10.0;
-        System.out.println("diff = " + diff);
-
         if(diff > 0) {
             String maxKey = result.entrySet().stream()
                     .max(Map.Entry.comparingByValue())
-                    .orElseThrow(() -> CustomException.of(ErrorCode.INTERNAL_SERVER_ERROR))
+                    .orElseThrow(() -> CustomException.of(ErrorCode.EXPERIENCES_NOT_ENOUGH))
                     .getKey();
 
             result.put(maxKey, result.get(maxKey) + diff);
         } else if(diff < 0) {
             String minKey = result.entrySet().stream()
                     .min(Map.Entry.comparingByValue())
-                    .orElseThrow(() -> CustomException.of(ErrorCode.INTERNAL_SERVER_ERROR))
+                    .orElseThrow(() -> CustomException.of(ErrorCode.EXPERIENCES_NOT_ENOUGH))
                     .getKey();
 
             result.put(minKey, result.get(minKey) - diff);


### PR DESCRIPTION
## 🔧 관련 이슈
- closed #110 

## 📌 PR 유형
- [x] 버그 수정

## 📝 작업 내용
- 직무 비율 로직에서 fetch된 경험이 존재하지 않을 때 INTERNAL_SERVER_ERROR발생 (getRecruitCount is null)
- 경험 리스트가 빈 값일 때 `CustomException` throw

## ✏️ 기타
