### PR TITLE
Fix/#115/fix code

### DIFF
--- a/src/main/java/com/itstime/xpact/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/controller/DashboardController.java
@@ -2,7 +2,7 @@ package com.itstime.xpact.domain.dashboard.controller;
 
 import com.itstime.xpact.domain.dashboard.dto.response.*;
 import com.itstime.xpact.domain.dashboard.service.DashboardService;
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 import com.itstime.xpact.global.response.ErrorResponse;
 import com.itstime.xpact.global.response.RestResponse;
@@ -49,7 +49,7 @@ public class DashboardController {
             content = @Content(schema = @Schema(implementation = MapResponseDto.class)))
     @PostMapping("/skills")
     public DeferredResult<ResponseEntity<?>> evaluateScore(
-            @RequestHeader("Authorization") String token) throws CustomException {
+            @RequestHeader("Authorization") String token) throws GeneralException {
 
         DeferredResult<ResponseEntity<?>> deferredResult = new DeferredResult<>(20_000L);
 

--- a/src/main/java/com/itstime/xpact/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/controller/DashboardController.java
@@ -122,4 +122,44 @@ public class DashboardController {
                 )
         );
     }
+
+    @PostMapping("/skills/feedback/strength")
+    public DeferredResult<ResponseEntity<?>> getFeedbackStrength() {
+
+        DeferredResult<ResponseEntity<?>> deferredResult = new DeferredResult<>(20_000L);
+
+        dashboardService.getStrengthFeedback()
+                .thenAccept(result -> {
+                    deferredResult.setResult(ResponseEntity.ok(
+                            RestResponse.ok(result)
+                    ));
+                })
+                .exceptionally(e -> {
+                    deferredResult.setErrorResult(
+                            ErrorResponse.toResponseEntity(ErrorCode.FAILED_GET_RESULT)
+                    );
+                    return null;
+                });
+        return deferredResult;
+    }
+
+    @PostMapping("/skills/feedback/weakness")
+    public DeferredResult<ResponseEntity<?>> getFeedbackWeakness() {
+
+        DeferredResult<ResponseEntity<?>> deferredResult = new DeferredResult<>(20_000L);
+
+        dashboardService.getWeaknessFeedback()
+                .thenAccept(result -> {
+                    deferredResult.setResult(ResponseEntity.ok(
+                            RestResponse.ok(result)
+                    ));
+                })
+                .exceptionally(e -> {
+                    deferredResult.setErrorResult(
+                            ErrorResponse.toResponseEntity(ErrorCode.FAILED_GET_RESULT)
+                    );
+                    return null;
+                });
+        return deferredResult;
+    }
 }

--- a/src/main/java/com/itstime/xpact/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/controller/DashboardController.java
@@ -1,8 +1,6 @@
 package com.itstime.xpact.domain.dashboard.controller;
 
-import com.itstime.xpact.domain.dashboard.dto.response.HistoryResponseDto;
-import com.itstime.xpact.domain.dashboard.dto.response.RatioResponseDto;
-import com.itstime.xpact.domain.dashboard.dto.response.TimelineResponseDto;
+import com.itstime.xpact.domain.dashboard.dto.response.*;
 import com.itstime.xpact.domain.dashboard.service.DashboardService;
 import com.itstime.xpact.global.exception.CustomException;
 import com.itstime.xpact.global.exception.ErrorCode;
@@ -11,8 +9,10 @@ import com.itstime.xpact.global.response.RestResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -33,6 +33,20 @@ public class DashboardController {
     @Operation(summary = "핵심스킬맵 요청 API", description = """
             핵심스킬맵 대시보드 반환을 위한 API입니다.
             """)
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "400", description = "저장된 경험이 없을 때의 에러 유형", content = @Content(schema = @Schema(implementation = ErrorResponse.class),
+                    examples = {
+                            @ExampleObject(name = "EXPERIENCES_NOT_ENOUGH", value = """
+                        {
+                              "httpStatus": "BAD_REQUEST",
+                              "code": "SME002",
+                              "message": "입력된 경험이 충분하지 않습니다."
+                        }""")
+                    }
+            ))
+    })
+    @ApiResponse(responseCode = "200", description = "핵심스킬맵 요청 성공",
+            content = @Content(schema = @Schema(implementation = MapResponseDto.class)))
     @PostMapping("/skills")
     public DeferredResult<ResponseEntity<?>> evaluateScore(
             @RequestHeader("Authorization") String token) throws CustomException {
@@ -123,6 +137,13 @@ public class DashboardController {
         );
     }
 
+    @Operation(summary = "핵심스킬맵 강점 역량 피드백 요청 API", description = """
+            사용자의 경험 기반으로 핵심 역량 중 강점에 대한 피드백을 제시합니다.<br>
+            expAnalysis는 경험 기반 분석으로,<br>
+            recommend는 커리어 연결로 매핑하시면 됩니다.
+            """)
+    @ApiResponse(responseCode = "200", description = "역량 피드백 요청 성공",
+            content = @Content(schema = @Schema(implementation = FeedbackResponseDto.class)))
     @PostMapping("/skills/feedback/strength")
     public DeferredResult<ResponseEntity<?>> getFeedbackStrength() {
 
@@ -143,6 +164,13 @@ public class DashboardController {
         return deferredResult;
     }
 
+    @Operation(summary = "핵심스킬맵 약점 역량 피드백 요청 API", description = """
+            사용자의 경험 기반으로 핵심 역량 중 약점에 대한 피드백을 제시합니다.<br>
+            expAnalysis는 경험 기반 분석으로,<br>
+            recommend는 추천 활동으로 매핑하시면 됩니다.
+            """)
+    @ApiResponse(responseCode = "200", description = "역량 피드백 요청 성공",
+            content = @Content(schema = @Schema(implementation = FeedbackResponseDto.class)))
     @PostMapping("/skills/feedback/weakness")
     public DeferredResult<ResponseEntity<?>> getFeedbackWeakness() {
 

--- a/src/main/java/com/itstime/xpact/domain/dashboard/controller/DashboardController.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/controller/DashboardController.java
@@ -31,14 +31,19 @@ public class DashboardController {
 
 
     @Operation(summary = "핵심스킬맵 요청 API", description = """
-            핵심스킬맵을 추출하기 위한 요청을 보내는 API입니다.<br>
-            
+            핵심스킬맵 대시보드 반환을 위한 API입니다.
             """)
     @PostMapping("/skills")
     public DeferredResult<ResponseEntity<?>> evaluateScore(
             @RequestHeader("Authorization") String token) throws CustomException {
 
-        DeferredResult<ResponseEntity<?>> deferredResult = new DeferredResult<>(30_000L);
+        DeferredResult<ResponseEntity<?>> deferredResult = new DeferredResult<>(20_000L);
+
+        deferredResult.onTimeout(() -> {
+            deferredResult.setErrorResult(
+                    ErrorResponse.toResponseEntity(ErrorCode.REQUEST_TIMEOUT)
+            );
+        });
 
         dashboardService.evaluateScore()
                 .thenAccept(result -> {

--- a/src/main/java/com/itstime/xpact/domain/dashboard/dto/response/FeedbackResponseDto.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/dto/response/FeedbackResponseDto.java
@@ -1,0 +1,13 @@
+package com.itstime.xpact.domain.dashboard.dto.response;
+
+import lombok.*;
+
+@Builder
+@Setter
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedbackResponseDto {
+    private String expAnalysis;
+    private String recommend;
+}

--- a/src/main/java/com/itstime/xpact/domain/dashboard/dto/response/FeedbackResponseDto.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/dto/response/FeedbackResponseDto.java
@@ -1,5 +1,6 @@
 package com.itstime.xpact.domain.dashboard.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 @Builder
@@ -7,7 +8,15 @@ import lombok.*;
 @Getter
 @NoArgsConstructor
 @AllArgsConstructor
+@Schema(description = "핵심역량에 대한 피드백 응답에 대한 DTO")
 public class FeedbackResponseDto {
+    @Schema(description = "사용자의 강점 및 약점 역량",
+    example = "사용자 중심 사고")
+    private String coreSkillName;
+    @Schema(description = "경험 기반 역량에 대한 분석 이유를 설명",
+    example = "뉴스 앱 기획 인턴 경험에서, 사용자 피드백 기반으로 UI 개선안을 도출하고, 사용성 중심의 기획 방향을 제안한 점이 주요하게 반영되었습니다.")
     private String expAnalysis;
+    @Schema(description = "커리어 연결 및 추천 활동",
+    example = "UX 기획, 프로덕트 매니지먼트 직무에서 큰 강점으로 작용할 수 있으며, 사용자 인터뷰 및 프로토타입 개선 과정에서의 리더십을 더욱 강화해보세요.")
     private String recommend;
 }

--- a/src/main/java/com/itstime/xpact/domain/dashboard/dto/response/MapResponseDto.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/dto/response/MapResponseDto.java
@@ -4,11 +4,9 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.RequiredArgsConstructor;
-import lombok.Setter;
 
 import java.util.List;
 
-@Setter
 @AllArgsConstructor
 @RequiredArgsConstructor
 @Data
@@ -40,5 +38,11 @@ public class MapResponseDto {
             ]
             """)
     private List<ScoreResponseDto> coreSkillMaps;
+    private String strength;
+    private String weakness;
 
+    public void setAnalysis(String strength, String weakness) {
+        this.strength = strength;
+        this.weakness = weakness;
+    }
 }

--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/DashboardService.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/DashboardService.java
@@ -1,9 +1,6 @@
 package com.itstime.xpact.domain.dashboard.service;
 
-import com.itstime.xpact.domain.dashboard.dto.response.HistoryResponseDto;
-import com.itstime.xpact.domain.dashboard.dto.response.MapResponseDto;
-import com.itstime.xpact.domain.dashboard.dto.response.RatioResponseDto;
-import com.itstime.xpact.domain.dashboard.dto.response.TimelineResponseDto;
+import com.itstime.xpact.domain.dashboard.dto.response.*;
 import com.itstime.xpact.domain.dashboard.service.ratio.RatioService;
 import com.itstime.xpact.domain.dashboard.service.skillmap.SkillmapService;
 import com.itstime.xpact.domain.dashboard.service.time.TimeService;
@@ -61,5 +58,21 @@ public class DashboardService {
         Member member = securityProvider.getCurrentMember();
 
         return timeService.getTimeLine(member, startLine, endLine);
+    }
+
+    // 피드백 부분 - 강점
+    public CompletableFuture<FeedbackResponseDto> getStrengthFeedback() {
+
+        Member member = securityProvider.getCurrentMember();
+
+        return skillmapService.getFeedbackStrength(member);
+    }
+
+    // 피드백 부분 - 단점
+    public CompletableFuture<FeedbackResponseDto> getWeaknessFeedback() {
+
+        Member member = securityProvider.getCurrentMember();
+
+        return skillmapService.getFeedbackWeakness(member);
     }
 }

--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/ratio/RatioService.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/ratio/RatioService.java
@@ -5,7 +5,7 @@ import com.itstime.xpact.domain.dashboard.entity.RecruitCount;
 import com.itstime.xpact.domain.dashboard.repository.RecruitCountRepository;
 import com.itstime.xpact.domain.experience.entity.Experience;
 import com.itstime.xpact.domain.experience.repository.ExperienceRepository;
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -82,7 +82,7 @@ public class RatioService {
         List<Experience> experiences = experienceRepository.findAllWithDetailRecruitByMemberId(memberId);
 
         if(experiences == null || experiences.isEmpty()) {
-            throw CustomException.of(ErrorCode.EXPERIENCES_NOT_ENOUGH);
+            throw GeneralException.of(ErrorCode.EXPERIENCES_NOT_ENOUGH);
         }
 
         Map<String, Integer> result = new HashMap<>();
@@ -107,14 +107,14 @@ public class RatioService {
         if(diff > 0) {
             String maxKey = result.entrySet().stream()
                     .max(Map.Entry.comparingByValue())
-                    .orElseThrow(() -> CustomException.of(ErrorCode.EXPERIENCES_NOT_ENOUGH))
+                    .orElseThrow(() -> GeneralException.of(ErrorCode.EXPERIENCES_NOT_ENOUGH))
                     .getKey();
 
             result.put(maxKey, result.get(maxKey) + diff);
         } else if(diff < 0) {
             String minKey = result.entrySet().stream()
                     .min(Map.Entry.comparingByValue())
-                    .orElseThrow(() -> CustomException.of(ErrorCode.EXPERIENCES_NOT_ENOUGH))
+                    .orElseThrow(() -> GeneralException.of(ErrorCode.EXPERIENCES_NOT_ENOUGH))
                     .getKey();
 
             result.put(minKey, result.get(minKey) - diff);

--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/skillmap/ScoreResultStore.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/skillmap/ScoreResultStore.java
@@ -1,42 +1,34 @@
 package com.itstime.xpact.domain.dashboard.service.skillmap;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class ScoreResultStore {
 
     private final RedisTemplate<String, String> redisTemplate;
 
-    public void save(Long memberId, String result) {
+    public void saveSkillMap(Long memberId, String result) {
         String key = "coreSkillMap:" + memberId;
         redisTemplate.opsForValue().set(key, result);
     }
 
-    public String get(Long memberId) {
+    public String getSkillMap(Long memberId) {
         String key = "coreSkillMap:" + memberId;
         return (String) redisTemplate.opsForValue().get(key);
     }
 
-    public void saveStrength(Long memberId, String strength) {
-        String key = "coreStrength:" + memberId;
-        redisTemplate.opsForValue().set(key, strength);
+    public void saveStrengthFeedback(Long memberId, String result) {
+        String key = "strengthFeedback:" + memberId;
+        redisTemplate.opsForValue().set(key, result);
     }
 
-    public void saveWeakness(Long memberId, String weakness) {
-        String key = "coreWeakness:" + memberId;
-        redisTemplate.opsForValue().set(key, weakness);
-    }
-
-    public String getStrength(Long memberId) {
-        String key = "coreStrength:" + memberId;
-        return (String) redisTemplate.opsForValue().get(key);
-    }
-
-    public String getWeakness(Long memberId) {
-        String key = "coreWeakness:" + memberId;
-        return (String) redisTemplate.opsForValue().get(key);
+    public void saveWeaknessFeedback(Long memberId, String result) {
+        String key = "weaknessFeedback:" + memberId;
+        redisTemplate.opsForValue().set(key, result);
     }
 }

--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/skillmap/ScoreResultStore.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/skillmap/ScoreResultStore.java
@@ -29,4 +29,14 @@ public class ScoreResultStore {
         String key = "coreWeakness:" + memberId;
         redisTemplate.opsForValue().set(key, weakness);
     }
+
+    public String getStrength(Long memberId) {
+        String key = "coreStrength:" + memberId;
+        return (String) redisTemplate.opsForValue().get(key);
+    }
+
+    public String getWeakness(Long memberId) {
+        String key = "coreWeakness:" + memberId;
+        return (String) redisTemplate.opsForValue().get(key);
+    }
 }

--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/skillmap/ScoreResultStore.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/skillmap/ScoreResultStore.java
@@ -19,4 +19,14 @@ public class ScoreResultStore {
         String key = "coreSkillMap:" + memberId;
         return (String) redisTemplate.opsForValue().get(key);
     }
+
+    public void saveStrength(Long memberId, String strength) {
+        String key = "coreStrength:" + memberId;
+        redisTemplate.opsForValue().set(key, strength);
+    }
+
+    public void saveWeakness(Long memberId, String weakness) {
+        String key = "coreWeakness:" + memberId;
+        redisTemplate.opsForValue().set(key, weakness);
+    }
 }

--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/skillmap/SkillmapService.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/skillmap/SkillmapService.java
@@ -11,6 +11,7 @@ import com.itstime.xpact.domain.recruit.entity.CoreSkill;
 import com.itstime.xpact.domain.recruit.entity.DetailRecruit;
 import com.itstime.xpact.domain.recruit.repository.DetailRecruitRepository;
 import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 import com.itstime.xpact.global.openai.OpenAiService;
 import lombok.RequiredArgsConstructor;
@@ -35,7 +36,7 @@ public class SkillmapService {
     private final DetailRecruitRepository detailRecruitRepository;
     private final ExperienceRepository experienceRepository;
 
-    public CompletableFuture<MapResponseDto> performEvaluation(Member member) throws CustomException {
+    public CompletableFuture<MapResponseDto> performEvaluation(Member member) throws GeneralException {
 
         String desiredRecruit = member.getDesiredRecruit();
         log.info("{} DetailRecruit 조회 시작...", desiredRecruit);
@@ -63,7 +64,7 @@ public class SkillmapService {
                         return analysisScore(member, resultDto);
                     } catch (Exception e) {
                         log.error("결과를 저장하는 것에 실패하였습니다.", e);
-                        throw CustomException.of(ErrorCode.FAILED_GET_RESULT);
+                        throw GeneralException.of(ErrorCode.FAILED_GET_RESULT);
                     }
                 });
     }
@@ -94,24 +95,24 @@ public class SkillmapService {
             return dto;
         } catch (JsonProcessingException e) {
             log.error("강점 및 약점 역량 저장 중 오류 ... : {}", e.getMessage());
-            throw CustomException.of(ErrorCode.FEEDBACK_SAVE_ERROR);
+            throw GeneralException.of(ErrorCode.FEEDBACK_SAVE_ERROR);
         }
     }
 
     // 피드백에 대한 조회 - 강점
-    public CompletableFuture<FeedbackResponseDto> getFeedbackStrength(Member member) throws CustomException {
+    public CompletableFuture<FeedbackResponseDto> getFeedbackStrength(Member member) throws GeneralException {
 
         String experiences = experienceRepository.findSummaryByMemberId(member.getId()).stream()
                 .collect(Collectors.joining("\n"));
         
         // 예외 처리 필요
         if (experiences == null || experiences.trim().isEmpty()) {
-            throw CustomException.of(ErrorCode.EXPERIENCES_NOT_ENOUGH);
+            throw GeneralException.of(ErrorCode.EXPERIENCES_NOT_ENOUGH);
         }
         
         String skillMap = scoreResultStore.getSkillMap(member.getId());
         if (skillMap == null || skillMap.trim().isEmpty()) {
-            throw CustomException.of(ErrorCode.SKILLMAP_NOT_FOUND);
+            throw GeneralException.of(ErrorCode.SKILLMAP_NOT_FOUND);
         }
 
         MapResponseDto skillMapDto;
@@ -119,12 +120,12 @@ public class SkillmapService {
             skillMapDto = objectMapper.readValue(skillMap, MapResponseDto.class);
         } catch (JsonProcessingException e) {
             log.error("객체로 역직렬화 실패", e);
-            throw CustomException.of(ErrorCode.FAILED_DESERIALIZE);
+            throw GeneralException.of(ErrorCode.FAILED_DESERIALIZE);
         }
 
         String strength = skillMapDto.getStrength();
         if (strength == null || strength.trim().isEmpty()) {
-            throw CustomException.of(ErrorCode.EMPTY_STRENGTH);
+            throw GeneralException.of(ErrorCode.EMPTY_STRENGTH);
         }
 
         return openAiService.feedbackStrength(experiences, strength)
@@ -136,25 +137,25 @@ public class SkillmapService {
                         return feedbackDto;
                     } catch (JsonProcessingException e) {
                         log.error("JSON 직렬화 실패", e);
-                        throw CustomException.of(ErrorCode.FAILED_SERIALIZE);
+                        throw GeneralException.of(ErrorCode.FAILED_SERIALIZE);
                     }
                 });
     }
 
     // 피드백에 대한 조회 - 약점
-    public CompletableFuture<FeedbackResponseDto> getFeedbackWeakness(Member member) throws CustomException {
+    public CompletableFuture<FeedbackResponseDto> getFeedbackWeakness(Member member) throws GeneralException {
 
         String experiences = experienceRepository.findSummaryByMemberId(member.getId()).stream()
                 .collect(Collectors.joining("\n"));
 
         // 예외 처리 필요
         if (experiences == null || experiences.trim().isEmpty()) {
-            throw CustomException.of(ErrorCode.EXPERIENCES_NOT_ENOUGH);
+            throw GeneralException.of(ErrorCode.EXPERIENCES_NOT_ENOUGH);
         }
 
         String skillMap = scoreResultStore.getSkillMap(member.getId());
         if (skillMap == null || skillMap.trim().isEmpty()) {
-            throw CustomException.of(ErrorCode.SKILLMAP_NOT_FOUND);
+            throw GeneralException.of(ErrorCode.SKILLMAP_NOT_FOUND);
         }
 
         MapResponseDto skillMapDto;
@@ -162,12 +163,12 @@ public class SkillmapService {
             skillMapDto = objectMapper.readValue(skillMap, MapResponseDto.class);
         } catch (JsonProcessingException e) {
             log.error("객체로 역직렬화 실패", e);
-            throw CustomException.of(ErrorCode.FAILED_DESERIALIZE);
+            throw GeneralException.of(ErrorCode.FAILED_DESERIALIZE);
         }
 
         String weakness = skillMapDto.getWeakness();
         if (weakness == null || weakness.trim().isEmpty()) {
-            throw CustomException.of(ErrorCode.EMPTY_STRENGTH);
+            throw GeneralException.of(ErrorCode.EMPTY_STRENGTH);
         }
 
         return openAiService.feedbackWeakness(experiences, weakness)
@@ -179,7 +180,7 @@ public class SkillmapService {
                         return feedbackDto;
                     } catch (JsonProcessingException e) {
                         log.error("JSON 직렬화 실패", e);
-                        throw CustomException.of(ErrorCode.FAILED_SERIALIZE);
+                        throw GeneralException.of(ErrorCode.FAILED_SERIALIZE);
                     }
                 });
     }

--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/skillmap/SkillmapService.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/skillmap/SkillmapService.java
@@ -1,6 +1,7 @@
 package com.itstime.xpact.domain.dashboard.service.skillmap;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.itstime.xpact.domain.dashboard.dto.response.FeedbackResponseDto;
 import com.itstime.xpact.domain.dashboard.dto.response.MapResponseDto;
 import com.itstime.xpact.domain.dashboard.dto.response.ScoreResponseDto;
 import com.itstime.xpact.domain.experience.repository.ExperienceRepository;
@@ -79,11 +80,29 @@ public class SkillmapService {
                 .max(Comparator.comparingDouble(ScoreResponseDto::getScore))
                 .map(ScoreResponseDto::getCoreSkillName)
                 .orElse(null);
-        scoreResultStore.saveWeakness(member.getId(), maxScoreSkill);
+        scoreResultStore.saveStrength(member.getId(), maxScoreSkill);
 
         if (minScoreSkill != null && maxScoreSkill != null) {
             dto.setAnalysis(maxScoreSkill, minScoreSkill);
         }
         return dto;
+    }
+
+    // 피드백에 대한 조회 - 강점
+    public CompletableFuture<FeedbackResponseDto> getFeedbackStrength(Member member) throws CustomException {
+
+        String experiences = experienceRepository.findSummaryByMemberId(member.getId()).stream()
+                .collect(Collectors.joining("\n"));
+
+        return openAiService.feedbackStrength(experiences, scoreResultStore.getStrength(member.getId()));
+    }
+
+    // 피드백에 대한 조회 - 약점
+    public CompletableFuture<FeedbackResponseDto> getFeedbackWeakness(Member member) throws CustomException {
+
+        String experiences = experienceRepository.findSummaryByMemberId(member.getId()).stream()
+                .collect(Collectors.joining("\n"));
+
+        return openAiService.feedbackWeakness(experiences, scoreResultStore.getWeakness(member.getId()));
     }
 }

--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/skillmap/SkillmapService.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/skillmap/SkillmapService.java
@@ -47,6 +47,11 @@ public class SkillmapService {
 
         List<String> coreSkillList = coreSkill.getCoreSKills();
 
+        // experiences가 null이거나 비어있는 경우 예외 처리
+        if (experiences == null || experiences.trim().isEmpty()) {
+            throw CustomException.of(ErrorCode.EXPERIENCES_NOT_ENOUGH);
+        }
+
         return openAiService.evaluateScore(experiences, coreSkillList)
                 .thenApply(resultDto -> {
                     try {

--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/time/TimeService.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/time/TimeService.java
@@ -6,7 +6,7 @@ import com.itstime.xpact.domain.dashboard.dto.response.TimelineResponseDto;
 import com.itstime.xpact.domain.experience.entity.Experience;
 import com.itstime.xpact.domain.experience.repository.ExperienceRepository;
 import com.itstime.xpact.domain.member.entity.Member;
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 import com.itstime.xpact.global.openai.OpenAiService;
 import lombok.RequiredArgsConstructor;
@@ -113,6 +113,6 @@ public class TimeService {
     }
 
     private void validateDate(int year, int month) {
-        if(year < 1 || month < 1 || month > 12) throw CustomException.of(ErrorCode.INVALID_DATE);
+        if(year < 1 || month < 1 || month > 12) throw GeneralException.of(ErrorCode.INVALID_DATE);
     }
 }

--- a/src/main/java/com/itstime/xpact/domain/experience/common/ExperienceType.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/common/ExperienceType.java
@@ -1,6 +1,6 @@
 package com.itstime.xpact.domain.experience.common;
 
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 
 import java.util.Set;
@@ -22,7 +22,7 @@ public enum ExperienceType {
         try {
             ExperienceType.valueOf(experienceType);
         } catch (Exception e) {
-            throw CustomException.of(ErrorCode.INVALID_EXPERIENCE_TYPE);
+            throw GeneralException.of(ErrorCode.INVALID_EXPERIENCE_TYPE);
         }
     }
 

--- a/src/main/java/com/itstime/xpact/domain/experience/common/FormType.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/common/FormType.java
@@ -1,6 +1,6 @@
 package com.itstime.xpact.domain.experience.common;
 
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 
 public enum FormType {
@@ -10,7 +10,7 @@ public enum FormType {
         try {
             FormType.valueOf(formType);
         } catch (Exception e) {
-            throw CustomException.of(ErrorCode.INVALID_FORMTYPE);
+            throw GeneralException.of(ErrorCode.INVALID_FORMTYPE);
         }
     }
 }

--- a/src/main/java/com/itstime/xpact/domain/experience/common/Status.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/common/Status.java
@@ -1,6 +1,6 @@
 package com.itstime.xpact.domain.experience.common;
 
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 
 public enum Status {
@@ -10,7 +10,7 @@ public enum Status {
         try {
             Status.valueOf(status);
         } catch (Exception e) {
-            throw CustomException.of(ErrorCode.INVALID_STATUS);
+            throw GeneralException.of(ErrorCode.INVALID_STATUS);
         }
     }
 }

--- a/src/main/java/com/itstime/xpact/domain/experience/controller/ExperienceController.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/controller/ExperienceController.java
@@ -3,7 +3,7 @@ package com.itstime.xpact.domain.experience.controller;
 import com.itstime.xpact.domain.experience.dto.request.ExperienceCreateRequestDto;
 import com.itstime.xpact.domain.experience.dto.request.ExperienceUpdateRequestDto;
 import com.itstime.xpact.domain.experience.service.ExperienceService;
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.response.ErrorResponse;
 import com.itstime.xpact.global.response.RestResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -55,7 +55,7 @@ public class ExperienceController {
     @PostMapping("")
     public ResponseEntity<RestResponse<?>> createExperience(
             @RequestBody ExperienceCreateRequestDto createRequestDto)
-    throws CustomException {
+    throws GeneralException {
 
         experienceService.create(createRequestDto);
         return ResponseEntity.ok(RestResponse.ok());
@@ -112,7 +112,7 @@ public class ExperienceController {
     public ResponseEntity<RestResponse<?>> updateExperience(
             @PathVariable("experience_id") Long experienceId,
             @RequestBody ExperienceUpdateRequestDto experienceUpdateRequestDto)
-    throws CustomException {
+    throws GeneralException {
 
         experienceService.update(experienceId, experienceUpdateRequestDto);
         return ResponseEntity.ok(RestResponse.ok());
@@ -144,7 +144,7 @@ public class ExperienceController {
     @DeleteMapping("/{experience_id}")
     public ResponseEntity<RestResponse<?>> deleteExperience(
             @PathVariable("experience_id") Long experienceId)
-    throws CustomException {
+    throws GeneralException {
 
         experienceService.delete(experienceId);
         return ResponseEntity.ok(RestResponse.ok());

--- a/src/main/java/com/itstime/xpact/domain/experience/controller/QueryExperienceController.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/controller/QueryExperienceController.java
@@ -3,7 +3,7 @@ package com.itstime.xpact.domain.experience.controller;
 import com.itstime.xpact.domain.experience.dto.response.DetailExperienceReadResponseDto;
 import com.itstime.xpact.domain.experience.dto.response.ThumbnailExperienceReadResponseDto;
 import com.itstime.xpact.domain.experience.service.QueryExperienceService;
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.response.ErrorResponse;
 import com.itstime.xpact.global.response.RestResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -45,7 +45,7 @@ public class QueryExperienceController {
     public ResponseEntity<RestResponse<List<ThumbnailExperienceReadResponseDto>>> readAllExperience(
             @RequestParam(value = "type", defaultValue = "ALL") List<String> types,
             @RequestParam(value = "order", defaultValue = "latest") String order)
-    throws CustomException {
+    throws GeneralException {
 
         return ResponseEntity.ok(RestResponse.ok(queryExperienceService.readAll(types, order.toUpperCase())));
     }
@@ -72,7 +72,7 @@ public class QueryExperienceController {
     @GetMapping("/{experience_id}")
     public ResponseEntity<RestResponse<DetailExperienceReadResponseDto>> readExperience(
             @PathVariable("experience_id") Long experienceId)
-    throws CustomException {
+    throws GeneralException {
 
         return ResponseEntity.ok(RestResponse.ok(queryExperienceService.read(experienceId)));
     }

--- a/src/main/java/com/itstime/xpact/domain/experience/entity/Keyword.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/entity/Keyword.java
@@ -1,7 +1,7 @@
 package com.itstime.xpact.domain.experience.entity;
 
 import com.itstime.xpact.domain.common.BaseEntity;
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 import jakarta.persistence.*;
 import lombok.*;
@@ -33,12 +33,12 @@ public class Keyword extends BaseEntity {
         if(keywords == null || keywords.isEmpty()) return;
 
         if(keywords.size() > 5) {
-            throw CustomException.of(ErrorCode.KEYWORD_EXCEEDED);
+            throw GeneralException.of(ErrorCode.KEYWORD_EXCEEDED);
         }
 
         keywords.forEach(keyword -> {
             if(keyword.length() > 20) {
-                throw CustomException.of(ErrorCode.KEYWORD_TOO_LONG);
+                throw GeneralException.of(ErrorCode.KEYWORD_TOO_LONG);
             }
         });
     }

--- a/src/main/java/com/itstime/xpact/domain/experience/service/ExperienceService.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/service/ExperienceService.java
@@ -9,7 +9,7 @@ import com.itstime.xpact.domain.experience.entity.*;
 import com.itstime.xpact.domain.experience.repository.ExperienceRepository;
 import com.itstime.xpact.domain.member.entity.Member;
 import com.itstime.xpact.global.auth.SecurityProvider;
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 import com.itstime.xpact.global.openai.OpenAiService;
 import lombok.RequiredArgsConstructor;
@@ -34,7 +34,7 @@ public class ExperienceService {
     private final SecurityProvider securityProvider;
     private final OpenAiService openAiService;
 
-    public void create(ExperienceCreateRequestDto createRequestDto) throws CustomException {
+    public void create(ExperienceCreateRequestDto createRequestDto) throws GeneralException {
         // member 조회
         Member member = securityProvider.getCurrentMember();
 
@@ -68,7 +68,7 @@ public class ExperienceService {
     }
 
     // keyword, fils 설정하여 set
-    private void saveNonQualification(Experience experience, ExperienceCreateRequestDto createRequestDto) throws CustomException {
+    private void saveNonQualification(Experience experience, ExperienceCreateRequestDto createRequestDto) throws GeneralException {
         // dto의 keywords를 keyword 엔티티로 변경
         if(createRequestDto.getKeywords() != null && !createRequestDto.getKeywords().isEmpty()) {
             List<Keyword> keywords = createRequestDto.getKeywords().stream()
@@ -91,21 +91,21 @@ public class ExperienceService {
         }
     }
 
-    public void update(Long experienceId, ExperienceUpdateRequestDto updateRequestDto) throws CustomException {
+    public void update(Long experienceId, ExperienceUpdateRequestDto updateRequestDto) throws GeneralException {
         Long currentMemberId = securityProvider.getCurrentMemberId();
 
         // experience 조회
         Experience experience = experienceRepository.findById(experienceId)
-                .orElseThrow(() -> CustomException.of(ErrorCode.EXPERIENCE_NOT_EXISTS));
+                .orElseThrow(() -> GeneralException.of(ErrorCode.EXPERIENCE_NOT_EXISTS));
 
         // 저장된 경험을 임시저장으로 돌리는 플로우 막는 로직
         if(Status.SAVE.equals(experience.getMetaData().getStatus()) && Status.DRAFT.equals(Status.valueOf(updateRequestDto.getStatus()))) {
-            throw CustomException.of(ErrorCode.INVALID_SAVE);
+            throw GeneralException.of(ErrorCode.INVALID_SAVE);
         }
 
 
         if(!experience.getMember().getId().equals(currentMemberId))
-            throw CustomException.of(ErrorCode.NOT_YOUR_EXPERIENCE);
+            throw GeneralException.of(ErrorCode.NOT_YOUR_EXPERIENCE);
 
         // enum타입이 될 string 필드 검증 로직 (INVALID한 값이 들어오면 CustomException발생)
         Status.validateStatus(updateRequestDto.getStatus());
@@ -157,10 +157,10 @@ public class ExperienceService {
         Long currentMemberId = securityProvider.getCurrentMemberId();
 
         Experience experience = experienceRepository.findById(experienceId)
-                .orElseThrow(() -> CustomException.of(ErrorCode.EXPERIENCE_NOT_EXISTS));
+                .orElseThrow(() -> GeneralException.of(ErrorCode.EXPERIENCE_NOT_EXISTS));
 
         if(!experience.getMember().getId().equals(currentMemberId)) {
-            throw CustomException.of(ErrorCode.NOT_YOUR_EXPERIENCE);
+            throw GeneralException.of(ErrorCode.NOT_YOUR_EXPERIENCE);
         }
 
         experienceRepository.delete(experience);

--- a/src/main/java/com/itstime/xpact/domain/experience/service/QueryExperienceService.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/service/QueryExperienceService.java
@@ -8,7 +8,7 @@ import com.itstime.xpact.domain.experience.repository.ExperienceRepository;
 import com.itstime.xpact.domain.member.entity.Member;
 import com.itstime.xpact.domain.member.repository.MemberRepository;
 import com.itstime.xpact.global.auth.SecurityProvider;
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
@@ -30,11 +30,11 @@ public class QueryExperienceService {
     private static final String OLDEST = "OLDEST";
     private static final String MODIFIED = "modifiedTime";
 
-    public List<ThumbnailExperienceReadResponseDto> readAll(List<String> types, String order) throws CustomException {
+    public List<ThumbnailExperienceReadResponseDto> readAll(List<String> types, String order) throws GeneralException {
 
         // member 조회
         Member member = memberRepository.findById(securityProvider.getCurrentMemberId()).orElseThrow(() ->
-                CustomException.of(ErrorCode.MEMBER_NOT_EXISTS));
+                GeneralException.of(ErrorCode.MEMBER_NOT_EXISTS));
 
         Sort sort;
         if(order.equals(LATEST)) {
@@ -42,7 +42,7 @@ public class QueryExperienceService {
         } else if(order.equals(OLDEST)) {
             sort = Sort.by(Sort.Direction.ASC, MODIFIED);
         } else {
-            throw CustomException.of(ErrorCode.INVALID_ORDER);
+            throw GeneralException.of(ErrorCode.INVALID_ORDER);
         }
 
         if(types.get(0).equalsIgnoreCase("all")) {
@@ -62,13 +62,13 @@ public class QueryExperienceService {
         }
     }
 
-    public DetailExperienceReadResponseDto read(Long experienceId) throws CustomException {
+    public DetailExperienceReadResponseDto read(Long experienceId) throws GeneralException {
         Experience experience = experienceRepository.findById(experienceId)
-                .orElseThrow(() -> CustomException.of(ErrorCode.EXPERIENCE_NOT_EXISTS));
+                .orElseThrow(() -> GeneralException.of(ErrorCode.EXPERIENCE_NOT_EXISTS));
 
         Long memberId = securityProvider.getCurrentMemberId();
         if(!experience.getMember().getId().equals(memberId))
-            throw new CustomException(ErrorCode.NOT_YOUR_EXPERIENCE);
+            throw new GeneralException(ErrorCode.NOT_YOUR_EXPERIENCE);
 
         return DetailExperienceReadResponseDto.of(experience);
     }

--- a/src/main/java/com/itstime/xpact/domain/member/service/EducationService.java
+++ b/src/main/java/com/itstime/xpact/domain/member/service/EducationService.java
@@ -9,7 +9,7 @@ import com.itstime.xpact.domain.member.entity.Member;
 import com.itstime.xpact.domain.member.repository.EducationRepository;
 import com.itstime.xpact.domain.member.repository.SchoolCustomRepositoryImpl;
 import com.itstime.xpact.domain.member.util.TrieUtil;
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -30,14 +30,14 @@ public class EducationService {
 
     // 학교 전체 조회
     @Transactional(readOnly = true)
-    public List<String> readSchoolNames() throws CustomException {
+    public List<String> readSchoolNames() throws GeneralException {
 
         return schoolCustomRepository.findAllSchoolNames();
     }
 
     // 학교 이름 검색함으로써 조회
     @Transactional(readOnly = true)
-    public List<String> autocompleteName(String term) throws CustomException {
+    public List<String> autocompleteName(String term) throws GeneralException {
 
         try {
             // Trie의 keyword에 검색어 넣기
@@ -50,7 +50,7 @@ public class EducationService {
             // prefix와 일치 반환
             return trieUtil.autocomplete(term);
         } catch (Exception e) {
-            throw CustomException.of(ErrorCode.INTERNAL_SERVER_ERROR);
+            throw GeneralException.of(ErrorCode.INTERNAL_SERVER_ERROR);
         } finally {
             // Trie 구조 다시 비우기
             trieUtil.deleteAutocompleteKeyword(term);
@@ -59,14 +59,14 @@ public class EducationService {
 
     // 학교를 기반으로 학과 필터링 ( 전체 조회 )
     @Transactional(readOnly = true)
-    public List<String> readMajor(String schoolName) throws CustomException {
+    public List<String> readMajor(String schoolName) throws GeneralException {
 
         return schoolCustomRepository.findMajorBySchoolName(schoolName);
     }
 
     // 직접 학과 검색
     @Transactional(readOnly = true)
-    public List<String> searchMajor(String schoolName, String term) throws CustomException {
+    public List<String> searchMajor(String schoolName, String term) throws GeneralException {
 
         try {
             // Trie의 keyword에 검색어 넣기
@@ -79,7 +79,7 @@ public class EducationService {
             // prefix와 일치 반환
             return trieUtil.autocomplete(term);
         } catch (Exception e) {
-            throw CustomException.of(ErrorCode.INTERNAL_SERVER_ERROR);
+            throw GeneralException.of(ErrorCode.INTERNAL_SERVER_ERROR);
         } finally {
             // Trie 구조 다시 비우기
             trieUtil.deleteAutocompleteKeyword(term);
@@ -138,7 +138,7 @@ public class EducationService {
 
         // Null에 대한 처리
         if (education == null && (requestDto.name() == null || requestDto.major() == null || requestDto.schoolStatus() == null)) {
-            throw CustomException.of(ErrorCode.INSUFFICIENT_SCHOOL_INFO);
+            throw GeneralException.of(ErrorCode.INSUFFICIENT_SCHOOL_INFO);
         }
 
         String name = requestDto.name() != null ? requestDto.name() : education != null ? education.getSchoolName() : null;

--- a/src/main/java/com/itstime/xpact/domain/member/util/TrieUtil.java
+++ b/src/main/java/com/itstime/xpact/domain/member/util/TrieUtil.java
@@ -21,7 +21,6 @@ public class TrieUtil {
     // Trie 키워드 조회
     public List<String> autocomplete(String keyword) {
         return (List<String>) this.trie
-                .prefixMap(keyword)
                 .keySet()
                 .stream()
                 .collect(Collectors.toList());

--- a/src/main/java/com/itstime/xpact/domain/recruit/service/CoreSkillService.java
+++ b/src/main/java/com/itstime/xpact/domain/recruit/service/CoreSkillService.java
@@ -58,7 +58,7 @@ public class CoreSkillService {
                 DetailRecruit detailRecruit = detailRecruitRepository.findByName(detailRecruitName)
                         .orElseThrow(() -> {
                             log.warn("DetailRecruit 조회 실패 : {}", detailRecruitName);
-                            return CustomException.of(ErrorCode.DETAILRECRUIT_NOT_FOUND);
+                            return CustomException.of(ErrorCode.DETAIL_RECRUIT_NOT_FOUND);
                         });
                 detailRecruit.setCoreSkill(coreSkillRepository.save(coreSkill));
                 coreSkills.add(coreSkill);

--- a/src/main/java/com/itstime/xpact/domain/recruit/service/CoreSkillService.java
+++ b/src/main/java/com/itstime/xpact/domain/recruit/service/CoreSkillService.java
@@ -5,7 +5,7 @@ import com.itstime.xpact.domain.recruit.entity.DetailRecruit;
 import com.itstime.xpact.domain.recruit.repository.CoreSkillRepository;
 import com.itstime.xpact.domain.recruit.repository.DetailRecruitRepository;
 import com.itstime.xpact.domain.recruit.repository.RecruitRepository;
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 import com.itstime.xpact.global.openai.OpenAiService;
 import lombok.RequiredArgsConstructor;
@@ -58,7 +58,7 @@ public class CoreSkillService {
                 DetailRecruit detailRecruit = detailRecruitRepository.findByName(detailRecruitName)
                         .orElseThrow(() -> {
                             log.warn("DetailRecruit 조회 실패 : {}", detailRecruitName);
-                            return CustomException.of(ErrorCode.DETAIL_RECRUIT_NOT_FOUND);
+                            return GeneralException.of(ErrorCode.DETAIL_RECRUIT_NOT_FOUND);
                         });
                 detailRecruit.setCoreSkill(coreSkillRepository.save(coreSkill));
                 coreSkills.add(coreSkill);

--- a/src/main/java/com/itstime/xpact/domain/recruit/service/RecruitService.java
+++ b/src/main/java/com/itstime/xpact/domain/recruit/service/RecruitService.java
@@ -9,7 +9,7 @@ import com.itstime.xpact.domain.recruit.repository.DetailRecruitRepository;
 import com.itstime.xpact.domain.recruit.repository.RecruitRepository;
 import com.itstime.xpact.global.auth.SecurityProvider;
 import com.itstime.xpact.infra.lambda.LambdaUtil;
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -34,7 +34,7 @@ public class RecruitService {
 
     // 산업 전체 조회
     @Transactional(readOnly = true)
-    public List<String> readAllRecruit() throws CustomException {
+    public List<String> readAllRecruit() throws GeneralException {
 
         securityProvider.getCurrentMemberId();
 
@@ -43,10 +43,10 @@ public class RecruitService {
 
     // 상세 직군 전체 조회
     @Transactional(readOnly = true)
-    public List<String> readAllDetailRecruits(String recruitName) throws CustomException {
+    public List<String> readAllDetailRecruits(String recruitName) throws GeneralException {
 
         Recruit recruit = recruitRepository.findByName(recruitName)
-                .orElseThrow(() -> CustomException.of(ErrorCode.RECRUIT_NOT_FOUND));
+                .orElseThrow(() -> GeneralException.of(ErrorCode.RECRUIT_NOT_FOUND));
         Long recruitId = recruit.getId();
 
         return detailRecruitRepository.findDetailRecruitNamesByRecruitId(recruitId);
@@ -54,7 +54,7 @@ public class RecruitService {
 
     // 희망 상세 직군 검색 자동완성
     @Transactional(readOnly = true)
-    public List<String> autocompleteDetail(String recruitName, String term) throws CustomException {
+    public List<String> autocompleteDetail(String recruitName, String term) throws GeneralException {
 
         try {
             securityProvider.getCurrentMemberId();
@@ -62,7 +62,7 @@ public class RecruitService {
             trieUtil.addAutocompleteKeyword(term);
 
             Recruit recruit = recruitRepository.findByName(recruitName) // Recruit name Unique
-                    .orElseThrow(() -> CustomException.of(ErrorCode.RECRUIT_NOT_FOUND));
+                    .orElseThrow(() -> GeneralException.of(ErrorCode.RECRUIT_NOT_FOUND));
 
             Long recruitId = recruit.getId();
 
@@ -72,7 +72,7 @@ public class RecruitService {
             return trieUtil.autocomplete(term);
         } catch (Exception e) {
             log.error("autocompleteDetail error: {}", e.getMessage());
-            throw CustomException.of(ErrorCode.INTERNAL_SERVER_ERROR);
+            throw GeneralException.of(ErrorCode.INTERNAL_SERVER_ERROR);
         } finally {
             trieUtil.deleteAutocompleteKeyword(term);
         }
@@ -80,13 +80,13 @@ public class RecruitService {
 
     // 희망 직군 저장
     @Transactional
-    public DesiredRecruitResponseDto updateDesiredRecruit(DesiredRecruitRequestDto requestDto) throws CustomException {
+    public DesiredRecruitResponseDto updateDesiredRecruit(DesiredRecruitRequestDto requestDto) throws GeneralException {
 
         // 실제 DB에서 영속 상태의 Member 조회
         Member member = securityProvider.getCurrentMember();
 
         if (requestDto.detailRecruitName() == null || requestDto.detailRecruitName().isBlank()) {
-            throw new CustomException(ErrorCode.EMPTY_DESIRED_RECRUIT);
+            throw new GeneralException(ErrorCode.EMPTY_DESIRED_RECRUIT);
         }
 
         member.setDesiredRecruit(requestDto.detailRecruitName());

--- a/src/main/java/com/itstime/xpact/global/aspect/LogAspect.java
+++ b/src/main/java/com/itstime/xpact/global/aspect/LogAspect.java
@@ -28,16 +28,11 @@ public class LogAspect {
         System.out.printf("[실행 API Controller] - %s.%s(%s)%n",
                 className, methodName, args.length > 0 ? args[0].toString() : "");
 
-        try {
-            Object result = joinPoint.proceed();
-            stopWatch.stop();
-            long time = stopWatch.getLastTaskTimeMillis();
+        Object result = joinPoint.proceed();
+        stopWatch.stop();
+        long time = stopWatch.getLastTaskTimeMillis();
 
-            System.out.printf("[API 종료] - %s.%s() - %d ms \n", className, methodName, time);
-            return result;
-        } catch (Throwable throwable) {
-            System.out.printf("[API 예외] - %s.%s(): %s%n", className, methodName, throwable.getMessage());
-            return null;
-        }
+        System.out.printf("[API 종료] - %s.%s() - %d ms \n", className, methodName, time);
+        return result;
     }
 }

--- a/src/main/java/com/itstime/xpact/global/aspect/LogAspect.java
+++ b/src/main/java/com/itstime/xpact/global/aspect/LogAspect.java
@@ -1,0 +1,43 @@
+package com.itstime.xpact.global.aspect;
+
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StopWatch;
+
+@Component
+@Aspect
+public class LogAspect {
+
+    @Pointcut("within(@org.springframework.web.bind.annotation.RestController com.itstime.xpact..*)")
+    public void controllerPointcut() {
+    }
+
+    @Around("controllerPointcut()")
+    public Object loggingAspect(ProceedingJoinPoint joinPoint) throws Throwable {
+
+        StopWatch stopWatch = new StopWatch();
+        stopWatch.start();
+
+        String className = joinPoint.getSignature().getDeclaringTypeName();
+        String methodName = joinPoint.getSignature().getName();
+        Object[] args = joinPoint.getArgs();
+
+        System.out.printf("[실행 API Controller] - %s.%s(%s)%n",
+                className, methodName, args.length > 0 ? args[0].toString() : "");
+
+        try {
+            Object result = joinPoint.proceed();
+            stopWatch.stop();
+            long time = stopWatch.getLastTaskTimeMillis();
+
+            System.out.printf("[API 종료] - %s.%s() - %d ms \n", className, methodName, time);
+            return result;
+        } catch (Throwable throwable) {
+            System.out.printf("[API 예외] - %s.%s(): %s%n", className, methodName, throwable.getMessage());
+            return null;
+        }
+    }
+}

--- a/src/main/java/com/itstime/xpact/global/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/itstime/xpact/global/auth/JwtAuthenticationFilter.java
@@ -3,7 +3,7 @@ package com.itstime.xpact.global.auth;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.itstime.xpact.domain.member.entity.Member;
 import com.itstime.xpact.domain.member.repository.MemberRepository;
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 import com.itstime.xpact.global.response.RestResponse;
 import jakarta.servlet.FilterChain;
@@ -65,7 +65,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
                 // ID(PK)를 통한 인증 생성
                 Member member = memberRepository.findById(memberId)
-                        .orElseThrow(() -> CustomException.of(ErrorCode.MEMBER_NOT_EXISTS));
+                        .orElseThrow(() -> GeneralException.of(ErrorCode.MEMBER_NOT_EXISTS));
 
                 MemberAuthentication authentication = MemberAuthentication.createMemberAuthentication(member);
 

--- a/src/main/java/com/itstime/xpact/global/auth/SecurityProvider.java
+++ b/src/main/java/com/itstime/xpact/global/auth/SecurityProvider.java
@@ -2,7 +2,7 @@ package com.itstime.xpact.global.auth;
 
 import com.itstime.xpact.domain.member.entity.Member;
 import com.itstime.xpact.domain.member.repository.MemberRepository;
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
@@ -23,18 +23,18 @@ public class SecurityProvider {
     // 현재 인증된 Member를 반환
     public Member getCurrentMember() {
         return memberRepository.findById(getMemberFromSecurityContext().getId()).orElseThrow(() ->
-                CustomException.of(ErrorCode.MEMBER_NOT_EXISTS));
+                GeneralException.of(ErrorCode.MEMBER_NOT_EXISTS));
     }
 
     private Member getMemberFromSecurityContext() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
         if (!(authentication instanceof MemberAuthentication memberAuth)) {
-            throw CustomException.of(ErrorCode.UNAUTHORIZED_ACCESS);
+            throw GeneralException.of(ErrorCode.UNAUTHORIZED_ACCESS);
         }
         Member member = memberAuth.getMember();
         if (member == null) {
-            throw CustomException.of(ErrorCode.MEMBER_NOT_EXISTS);
+            throw GeneralException.of(ErrorCode.MEMBER_NOT_EXISTS);
         }
         return member;
     }

--- a/src/main/java/com/itstime/xpact/global/auth/TokenProvider.java
+++ b/src/main/java/com/itstime/xpact/global/auth/TokenProvider.java
@@ -21,8 +21,6 @@ import java.util.Date;
 @Slf4j
 public class TokenProvider {
 
-    private final RedisTemplate<String, String> redisTemplate;
-
     private static final String KEY_ROLES = "roles";
 
     @Value("${spring.jwt.secret}")

--- a/src/main/java/com/itstime/xpact/global/auth/TokenProvider.java
+++ b/src/main/java/com/itstime/xpact/global/auth/TokenProvider.java
@@ -1,16 +1,13 @@
 package com.itstime.xpact.global.auth;
 
 import com.itstime.xpact.domain.member.entity.Member;
-import com.itstime.xpact.domain.member.repository.MemberRepository;
-import com.itstime.xpact.global.exception.CustomException;
-import com.itstime.xpact.global.exception.CustomExceptionHandler;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 import com.itstime.xpact.global.response.RestResponse;
 import io.jsonwebtoken.*;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
@@ -77,7 +74,7 @@ public class TokenProvider {
         String memberId = claims.getSubject();
 
         if(!StringUtils.hasText(memberId)) {
-            throw CustomException.of(ErrorCode.FAILED_JWT_INFO);
+            throw GeneralException.of(ErrorCode.FAILED_JWT_INFO);
         }
         return Long.parseLong(memberId);
     }
@@ -92,25 +89,25 @@ public class TokenProvider {
     }
 
     // JWT 검증
-    public RestResponse<?> validationToken(String token) throws CustomException {
+    public RestResponse<?> validationToken(String token) throws GeneralException {
         try {
             final Claims claims = getClaims(token);
             return RestResponse.ok(claims);
         } catch (MalformedJwtException e) {
             log.warn("유효하지 않은 JWT token: {}", e.getMessage());
-            throw CustomException.of(ErrorCode.INVALID_JWT_TOKEN);
+            throw GeneralException.of(ErrorCode.INVALID_JWT_TOKEN);
         } catch (SignatureException e) {
             log.warn("유효하지 않은 서명의 JWT token: {}", e.getMessage());
-            throw CustomException.of(ErrorCode.INVALID_JWT_SIGNATURE);
+            throw GeneralException.of(ErrorCode.INVALID_JWT_SIGNATURE);
         } catch (ExpiredJwtException e) {
             log.warn("만료된 JWT token: {}", e.getMessage());
-            throw CustomException.of(ErrorCode.EXPIRED_JWT_TOKEN);
+            throw GeneralException.of(ErrorCode.EXPIRED_JWT_TOKEN);
         } catch (UnsupportedJwtException e) {
             log.warn("지원하지 않는 JWT token: {}", e.getMessage());
-            throw CustomException.of(ErrorCode.UNSUPPORTED_JWT_TOKEN);
+            throw GeneralException.of(ErrorCode.UNSUPPORTED_JWT_TOKEN);
         } catch (IllegalArgumentException ex) {
             log.warn("Empty JWT token: {}", ex.getMessage());
-            throw CustomException.of(ErrorCode.TOKEN_NOT_FOUND);
+            throw GeneralException.of(ErrorCode.TOKEN_NOT_FOUND);
         }
     }
 }

--- a/src/main/java/com/itstime/xpact/global/config/RestTemplateConfig.java
+++ b/src/main/java/com/itstime/xpact/global/config/RestTemplateConfig.java
@@ -13,9 +13,6 @@ import java.util.List;
 
 @Configuration
 public class RestTemplateConfig {
-    // 서버에서 HTTP 요청을 보내기 위한 템플릿 설정
-    // TODO : 비동기 처리 및 확장성을 위하여 WebClient로의 확장도 고려
-    // TODO : Feign Client를 자주 사용하는 MSA 구조에 대하여 고려해보기
 
     @Bean
     public RestTemplate restTemplate() {

--- a/src/main/java/com/itstime/xpact/global/exception/CustomException.java
+++ b/src/main/java/com/itstime/xpact/global/exception/CustomException.java
@@ -5,7 +5,7 @@ public class CustomException extends RuntimeException {
     private ErrorCode errorCode;
 
     public CustomException(ErrorCode errorCode) {
-        super(errorCode.getMessage()); // RuntimeException으로 전달
+        super(errorCode.getMessage());
         this.errorCode = errorCode;
     }
 

--- a/src/main/java/com/itstime/xpact/global/exception/CustomExceptionHandler.java
+++ b/src/main/java/com/itstime/xpact/global/exception/CustomExceptionHandler.java
@@ -1,6 +1,7 @@
 package com.itstime.xpact.global.exception;
 
 import com.itstime.xpact.global.response.ErrorResponse;
+import com.itstime.xpact.global.response.RestResponse;
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
@@ -14,11 +15,19 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class CustomExceptionHandler {
 
-    // CustomException ( RuntimeException )
-    @ExceptionHandler(CustomException.class)
-    protected ResponseEntity<ErrorResponse> customException(CustomException e, HttpServletRequest request) {
+    // GeneralException ( RuntimeException )
+    @ExceptionHandler(GeneralException.class)
+    protected ResponseEntity<ErrorResponse> generalException(GeneralException e, HttpServletRequest request) {
         logError(e, request);
         return ErrorResponse.toResponseEntity(e.getErrorCode());
+    }
+
+    // CustomException - 상태코드는 200이지만, ErrorCode에 대한 예외를 처리
+    protected ResponseEntity<RestResponse<Void>> customException(CustomException e, HttpServletRequest request) {
+        logError(e, request);
+        return ResponseEntity.ok(
+                RestResponse.onFailure(e.getErrorCode())
+        );
     }
 
     // Header missing Exception

--- a/src/main/java/com/itstime/xpact/global/exception/ErrorCode.java
+++ b/src/main/java/com/itstime/xpact/global/exception/ErrorCode.java
@@ -78,11 +78,13 @@ public enum ErrorCode {
 
     // coreSkill
     NOT_FOUND_CORESKILLS(HttpStatus.BAD_REQUEST, "CSE001", "해당 핵심 역량을 불러오는 데에 실패했습니다."),
-    DETAILRECRUIT_NOT_FOUND(HttpStatus.BAD_REQUEST, "CSE002", "찾을 수 없습니다."),
+    DETAILRECRUIT_NOT_FOUND(HttpStatus.BAD_REQUEST, "CSE002", "입력된 경험을 찾을 수 없습니다."),
 
     // skill map
     UNLOADED_SKILL_MAP(HttpStatus.BAD_REQUEST, "SME001", "핵심 스킬맵 로드에 실패하였습니다."),
     EXPERIENCES_NOT_ENOUGH(HttpStatus.BAD_REQUEST, "SME002", "입력된 경험이 충분하지 않습니다."),
+    EMPTY_STRENGTH(HttpStatus.NOT_FOUND, "SME003", "핵심역량 중 강점 부분이 저장되지 않았습니다."),
+    EMPTY_WEAKNESS(HttpStatus.NOT_FOUND, "SME004", "핵심역량 중 약점 부분이 저장되지 않았습니다."),
 
     // Async
     FAILED_GET_RESULT(HttpStatus.BAD_REQUEST, "AE001", "요청에 대한 응답을 얻지 못했습니다."),

--- a/src/main/java/com/itstime/xpact/global/exception/ErrorCode.java
+++ b/src/main/java/com/itstime/xpact/global/exception/ErrorCode.java
@@ -78,13 +78,15 @@ public enum ErrorCode {
 
     // coreSkill
     NOT_FOUND_CORESKILLS(HttpStatus.BAD_REQUEST, "CSE001", "해당 핵심 역량을 불러오는 데에 실패했습니다."),
-    DETAILRECRUIT_NOT_FOUND(HttpStatus.BAD_REQUEST, "CSE003", "찾을 수 없습니다."),
+    DETAILRECRUIT_NOT_FOUND(HttpStatus.BAD_REQUEST, "CSE002", "찾을 수 없습니다."),
 
     // skill map
     UNLOADED_SKILL_MAP(HttpStatus.BAD_REQUEST, "SME001", "핵심 스킬맵 로드에 실패하였습니다."),
+    EXPERIENCES_NOT_ENOUGH(HttpStatus.BAD_REQUEST, "SME002", "입력된 경험이 충분하지 않습니다."),
 
     // Async
     FAILED_GET_RESULT(HttpStatus.BAD_REQUEST, "AE001", "요청에 대한 응답을 얻지 못했습니다."),
+    REQUEST_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "AE002", "요청 시간이 초과되었습니다."),
 
     // etc
     INVALID_DATE(HttpStatus.BAD_REQUEST, "ETC001", "잘못된 날짜입니다."),

--- a/src/main/java/com/itstime/xpact/global/exception/ErrorCode.java
+++ b/src/main/java/com/itstime/xpact/global/exception/ErrorCode.java
@@ -78,17 +78,22 @@ public enum ErrorCode {
 
     // coreSkill
     NOT_FOUND_CORESKILLS(HttpStatus.BAD_REQUEST, "CSE001", "해당 핵심 역량을 불러오는 데에 실패했습니다."),
-    DETAILRECRUIT_NOT_FOUND(HttpStatus.BAD_REQUEST, "CSE002", "입력된 경험을 찾을 수 없습니다."),
 
     // skill map
     UNLOADED_SKILL_MAP(HttpStatus.BAD_REQUEST, "SME001", "핵심 스킬맵 로드에 실패하였습니다."),
     EXPERIENCES_NOT_ENOUGH(HttpStatus.BAD_REQUEST, "SME002", "입력된 경험이 충분하지 않습니다."),
     EMPTY_STRENGTH(HttpStatus.NOT_FOUND, "SME003", "핵심역량 중 강점 부분이 저장되지 않았습니다."),
     EMPTY_WEAKNESS(HttpStatus.NOT_FOUND, "SME004", "핵심역량 중 약점 부분이 저장되지 않았습니다."),
+    FEEDBACK_SAVE_ERROR(HttpStatus.BAD_REQUEST, "SME005", "핵심역량의 강점 및 약점을 저장하는 데에 오류가 발생하였습니다."),
+    SKILLMAP_NOT_FOUND(HttpStatus.NOT_FOUND, "SME006", "저장된 핵심스킬맵이 존재하지 않습니다."),
 
     // Async
     FAILED_GET_RESULT(HttpStatus.BAD_REQUEST, "AE001", "요청에 대한 응답을 얻지 못했습니다."),
     REQUEST_TIMEOUT(HttpStatus.REQUEST_TIMEOUT, "AE002", "요청 시간이 초과되었습니다."),
+
+    // json
+    FAILED_DESERIALIZE(HttpStatus.BAD_REQUEST, "JE001", "역직렬화에 실패하였습니다."),
+    FAILED_SERIALIZE(HttpStatus.BAD_REQUEST, "JE002", "직렬화에 실패하였습니다."),
 
     // etc
     INVALID_DATE(HttpStatus.BAD_REQUEST, "ETC001", "잘못된 날짜입니다."),

--- a/src/main/java/com/itstime/xpact/global/exception/GeneralException.java
+++ b/src/main/java/com/itstime/xpact/global/exception/GeneralException.java
@@ -1,0 +1,19 @@
+package com.itstime.xpact.global.exception;
+
+public class GeneralException extends RuntimeException {
+
+    private ErrorCode errorCode;
+
+    public GeneralException(ErrorCode errorCode) {
+        super(errorCode.getMessage()); // RuntimeException으로 전달
+        this.errorCode = errorCode;
+    }
+
+    public ErrorCode getErrorCode() {
+        return errorCode;
+    }
+
+    public static GeneralException of(ErrorCode errorCode) {
+        return new GeneralException(errorCode);
+    }
+}

--- a/src/main/java/com/itstime/xpact/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/itstime/xpact/global/exception/GlobalExceptionHandler.java
@@ -13,7 +13,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @Slf4j
 @Hidden
 @RestControllerAdvice
-public class CustomExceptionHandler {
+public class GlobalExceptionHandler {
 
     // GeneralException ( RuntimeException )
     @ExceptionHandler(GeneralException.class)
@@ -23,6 +23,7 @@ public class CustomExceptionHandler {
     }
 
     // CustomException - 상태코드는 200이지만, ErrorCode에 대한 예외를 처리
+    @ExceptionHandler(CustomException.class)
     protected ResponseEntity<RestResponse<Void>> customException(CustomException e, HttpServletRequest request) {
         logError(e, request);
         return ResponseEntity.ok(

--- a/src/main/java/com/itstime/xpact/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/itstime/xpact/global/exception/GlobalExceptionHandler.java
@@ -5,6 +5,7 @@ import com.itstime.xpact.global.response.RestResponse;
 import io.swagger.v3.oas.annotations.Hidden;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.MissingRequestHeaderException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
@@ -24,11 +25,11 @@ public class GlobalExceptionHandler {
 
     // CustomException - 상태코드는 200이지만, ErrorCode에 대한 예외를 처리
     @ExceptionHandler(CustomException.class)
-    protected ResponseEntity<RestResponse<Void>> customException(CustomException e, HttpServletRequest request) {
+    protected ResponseEntity<RestResponse<?>> customException(CustomException e, HttpServletRequest request) {
         logError(e, request);
-        return ResponseEntity.ok(
-                RestResponse.onFailure(e.getErrorCode())
-        );
+        return ResponseEntity.status(HttpStatus.OK)
+                .body(RestResponse.onFailure(e.getErrorCode())
+                );
     }
 
     // Header missing Exception

--- a/src/main/java/com/itstime/xpact/global/openai/OpenAiRequestBuilder.java
+++ b/src/main/java/com/itstime/xpact/global/openai/OpenAiRequestBuilder.java
@@ -9,10 +9,17 @@ public class OpenAiRequestBuilder {
 
     public String buildScorePrompt(String experiences, List<String> coreSkills) {
             StringBuilder builder = new StringBuilder();
-            builder.append("다음은 나의 경험 요약본들을 모은 것이다.\n\n");
+            builder.append("당신은 인사 전문가이며, 지원자의 직무 역량을 평가하는 \"AI evaluator for job competency\"이다.\n");
+            builder.append("다음은 지원자의 경험 요약본들을 모은 것이다.\n\n");
             builder.append(experiences).append("\n");
-            builder.append("주어진 역량 키워드 각각에 대해 0.0 ~ 10.0의 점수를 부여해줘.\n");
-            builder.append("경험을 종합적으로 고려해, 각 역량이 어느 정도 드러나는지 판단해 객관적으로 점수를 부여해줘.\n");
+            builder.append("주어진 역량 키워드 각각에 대해 지원자가 직무에서 보여준 역량을 객관적으로 평가해줘.");
+            builder.append("평가지침은 다음과 같다.\n");
+            builder.append("""
+                    1. 각 역량 키워드에 대해 설명 없이 0.0 ~ 10.0 사이의 소수점 1자리 점수를 부여한다.
+                    2. 점수는 해당 역량이 경험에서 얼마나 명확히 드러나는지를 기준으로 정량적으로 평가해라.
+                    3. 모든 역량의 점수는 서로 중복되지 않도록 고유한 값을 가져야한다.
+                    4. 경험이 명확히 부족한 경우에는 0.0 또는 그에 가까운 낮은 점수를 부여한다.
+                    """);
 
             for (int i = 0; i < coreSkills.size(); i++) {
                 builder.append(String.format("{core_skill_%d}/", i+1));

--- a/src/main/java/com/itstime/xpact/global/openai/OpenAiRequestBuilder.java
+++ b/src/main/java/com/itstime/xpact/global/openai/OpenAiRequestBuilder.java
@@ -8,16 +8,16 @@ import java.util.*;
 public class OpenAiRequestBuilder {
 
     public String buildScorePrompt(String experiences, List<String> coreSkills) {
-        StringBuilder builder = new StringBuilder();
-        builder.append("다음은 나의 경험 요약본들을 모은 것이다.\n\n");
-        builder.append(experiences).append("\n");
-        builder.append("주어진 역량 키워드 각각에 대해 0.0 ~ 10.0의 점수를 부여해줘.\n");
-        builder.append("경험을 종합적으로 고려해, 각 역량이 어느 정도 드러나는지 판단해 객관적으로 점수를 부여해줘.\n");
+            StringBuilder builder = new StringBuilder();
+            builder.append("다음은 나의 경험 요약본들을 모은 것이다.\n\n");
+            builder.append(experiences).append("\n");
+            builder.append("주어진 역량 키워드 각각에 대해 0.0 ~ 10.0의 점수를 부여해줘.\n");
+            builder.append("경험을 종합적으로 고려해, 각 역량이 어느 정도 드러나는지 판단해 객관적으로 점수를 부여해줘.\n");
 
-        for (int i = 0; i < coreSkills.size(); i++) {
-            builder.append(String.format("{core_skill_%d}/", i+1));
-        }
-        return builder.toString();
+            for (int i = 0; i < coreSkills.size(); i++) {
+                builder.append(String.format("{core_skill_%d}/", i+1));
+            }
+            return builder.toString();
     }
 
     public Map<String, String> buildScoreVariables(String experiences, List<String> coreSkills) {

--- a/src/main/java/com/itstime/xpact/global/openai/OpenAiRequestBuilder.java
+++ b/src/main/java/com/itstime/xpact/global/openai/OpenAiRequestBuilder.java
@@ -7,6 +7,7 @@ import java.util.*;
 @Slf4j
 public class OpenAiRequestBuilder {
 
+    // Score 산정
     public String buildScorePrompt(String experiences, List<String> coreSkills) {
             StringBuilder builder = new StringBuilder();
             builder.append("당신은 인사 전문가이며, 지원자의 직무 역량을 평가하는 \"AI evaluator for job competency\"이다.\n");
@@ -34,5 +35,29 @@ public class OpenAiRequestBuilder {
             variables.put("core_skill_"+ (i+1), coreSkills.get(i));
         }
         return variables;
+    }
+
+    // Feedback with Strength
+    public String buildStrengthPrompt(String experiences, String strength) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(strength).append("은 나의 경험 중 강점인 역량이다.\n");
+        builder.append("첫번째 문단은 내 경험들을 토대로 50자 내외로 해당 역량이 강점인 이유 대하여 서술해줘.\n");
+        builder.append("두번째 문단은 내 경험들을 토대로 50자 내외로 연결할 수 있는 커리어에 대하여 추천해줘.\n");
+        builder.append("나의 경험들은 다음과 같다.\n");
+        builder.append(experiences);
+
+        return builder.toString();
+    }
+
+    // Feedback with Weakness
+    public String buildWeaknessPrompt(String experiences, String weakness) {
+        StringBuilder builder = new StringBuilder();
+        builder.append(weakness).append("은 나의 경험 중 부족한 역량이다.\n");
+        builder.append("첫번째 문단은 내 경험들을 토대로 50자 내외로 해당 역량이 약점인 이유 대하여 분석해줘.\n");
+        builder.append("두번째 문단은 내 경험들을 토대로 50자 내외로 보완할 수 있는 추천 활동들을 제시해줘.\n");
+        builder.append("나의 경험들은 다음과 같다.\n");
+        builder.append(experiences);
+
+        return builder.toString();
     }
 }

--- a/src/main/java/com/itstime/xpact/global/openai/OpenAiService.java
+++ b/src/main/java/com/itstime/xpact/global/openai/OpenAiService.java
@@ -1,5 +1,6 @@
 package com.itstime.xpact.global.openai;
 
+import com.itstime.xpact.domain.dashboard.dto.response.FeedbackResponseDto;
 import com.itstime.xpact.domain.dashboard.dto.response.MapResponseDto;
 import com.itstime.xpact.domain.experience.entity.Experience;
 import org.springframework.scheduling.annotation.Async;
@@ -20,4 +21,7 @@ public interface OpenAiService {
 
     @Async("taskExecutor")
     void getDetailRecruitFromExperience(Experience experience);
+
+    CompletableFuture<FeedbackResponseDto> feedbackStrength(String experiences, String strength);
+    CompletableFuture<FeedbackResponseDto> feedbackWeakness(String experiences, String weakness);
 }

--- a/src/main/java/com/itstime/xpact/global/openai/OpenAiServiceImpl.java
+++ b/src/main/java/com/itstime/xpact/global/openai/OpenAiServiceImpl.java
@@ -8,7 +8,7 @@ import com.itstime.xpact.domain.experience.entity.Experience;
 import com.itstime.xpact.domain.experience.repository.ExperienceRepository;
 import com.itstime.xpact.domain.recruit.entity.DetailRecruit;
 import com.itstime.xpact.domain.recruit.repository.DetailRecruitRepository;
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -93,7 +93,7 @@ public class OpenAiServiceImpl implements OpenAiService {
     }
 
     @Async
-    public CompletableFuture<MapResponseDto> evaluateScore(String experiences, List<String> coreSkills) throws CustomException {
+    public CompletableFuture<MapResponseDto> evaluateScore(String experiences, List<String> coreSkills) throws GeneralException {
 
         OpenAiRequestBuilder builder = new OpenAiRequestBuilder();
 
@@ -117,7 +117,7 @@ public class OpenAiServiceImpl implements OpenAiService {
         } catch (JsonProcessingException e) {
             log.info("응답 내용 :" + rawResponse);
             log.error("readValue 불가...", e);
-            throw CustomException.of(ErrorCode.FAILED_OPENAI_PARSING);
+            throw GeneralException.of(ErrorCode.FAILED_OPENAI_PARSING);
         }
     }
 
@@ -197,7 +197,7 @@ public class OpenAiServiceImpl implements OpenAiService {
         String result = response.getResult().getOutput().getText();
         log.info("result : {}", result);
         DetailRecruit detailRecruit = detailRecruitRepository.findByName(result).orElseThrow(() ->
-                CustomException.of(ErrorCode.DETAIL_RECRUIT_NOT_FOUND));
+                GeneralException.of(ErrorCode.DETAIL_RECRUIT_NOT_FOUND));
 
         experience.setDetailRecruit(detailRecruit);
         experienceRepository.save(experience);

--- a/src/main/java/com/itstime/xpact/global/openai/OpenAiServiceImpl.java
+++ b/src/main/java/com/itstime/xpact/global/openai/OpenAiServiceImpl.java
@@ -123,6 +123,7 @@ public class OpenAiServiceImpl implements OpenAiService {
 
     private String buildSystemInstruction(List<String> coreSkills) {
         StringBuilder builder = new StringBuilder();
+        builder.append("You are an AI evaluator for job competency. ");
         builder.append("Explain Korean. Follow the format below.\n{\n");
         builder.append("\"coreSkillMaps\": [\n{");
         for (String coreSkill : coreSkills) {
@@ -133,6 +134,18 @@ public class OpenAiServiceImpl implements OpenAiService {
         builder.append("}");
         return builder.toString();
     }
+
+    // 강점 피드백
+    public String feedbackStrength(String strength) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("다음은 나의 역량에 대한 강점이다.\n");
+        builder.append("내 경험들을 토대로 50자 내외로 분석에 대하여 피드백을 줘.\n");
+        builder.append("또한 50자 내외로 커리어 연결에 대하여 피드백을 줘.");
+
+        Prompt prompt = new Prompt(builder.toString());
+        return openAiChatModel.call(prompt).toString();
+    }
+
 
     public void getDetailRecruitFromExperience(Experience experience) {
         String experienceStr = experience.toString();

--- a/src/main/java/com/itstime/xpact/global/openai/OpenAiServiceImpl.java
+++ b/src/main/java/com/itstime/xpact/global/openai/OpenAiServiceImpl.java
@@ -144,19 +144,21 @@ public class OpenAiServiceImpl implements OpenAiService {
         String message = template.render();
 
         Message userMessage = new UserMessage(message);
-        Message systemMessage = new SystemMessage("두 개의 문단으로 답해라.");
+        Message systemMessage = new SystemMessage("두 개의 문단으로 답해라. 존댓말을 써라.");
 
         String rawResponse = openAiChatModel.call(systemMessage, userMessage);
 
         String[] paragraphs = rawResponse.split("\\n\\n", 2);
 
         FeedbackResponseDto dto = new FeedbackResponseDto();
+        dto.setCoreSkillName(strength);
         dto.setExpAnalysis(paragraphs.length > 0 ? paragraphs[0].trim() : "");
         dto.setRecommend(paragraphs.length > 1 ? paragraphs[1].trim() : "");
 
         return CompletableFuture.completedFuture(dto);
     };
 
+    // 약점 피드백
     public CompletableFuture<FeedbackResponseDto> feedbackWeakness(String experiences, String weakness) {
         OpenAiRequestBuilder builder = new OpenAiRequestBuilder();
 
@@ -164,29 +166,19 @@ public class OpenAiServiceImpl implements OpenAiService {
         String message = template.render();
 
         Message userMessage = new UserMessage(message);
-        Message systemMessage = new SystemMessage("두 개의 문단으로 답해라.");
+        Message systemMessage = new SystemMessage("두 개의 문단으로 답해라. 존댓말을 써라.");
 
         String rawResponse = openAiChatModel.call(systemMessage, userMessage);
 
-        String[] paragraphs = rawResponse.split("\\n\\n", 2); // 문단 기준으로 나눔
+        String[] paragraphs = rawResponse.split("\\n\\n", 2);
 
         FeedbackResponseDto dto = new FeedbackResponseDto();
+        dto.setCoreSkillName(weakness);
         dto.setExpAnalysis(paragraphs.length > 0 ? paragraphs[0].trim() : "");
         dto.setRecommend(paragraphs.length > 1 ? paragraphs[1].trim() : "");
 
         return CompletableFuture.completedFuture(dto);
     };
-
-
-    public String feedbackWeakness(String weakness) {
-        StringBuilder builder = new StringBuilder();
-        builder.append("다음은 나의 역량에 대한 강점이다.\n");
-        builder.append("내 경험들을 토대로 50자 내외로 분석에 대하여 피드백을 줘.\n");
-        builder.append("또한 50자 내외로 커리어 연결에 대하여 피드백을 줘.");
-
-        Prompt prompt = new Prompt(builder.toString());
-        return openAiChatModel.call(prompt).toString();
-    }
 
 
     public void getDetailRecruitFromExperience(Experience experience) {

--- a/src/main/java/com/itstime/xpact/global/response/RestResponse.java
+++ b/src/main/java/com/itstime/xpact/global/response/RestResponse.java
@@ -10,6 +10,8 @@ import lombok.Data;
 @Builder
 public class RestResponse<T> {
 
+    @Schema(example = "true")
+    private boolean isSuccess;
     @Schema(example = "200")
     private int httpStatus;
     @Schema(example = "success")
@@ -22,6 +24,7 @@ public class RestResponse<T> {
      */
     public static<T> RestResponse<T> ok(final T data) {
         return RestResponse.<T>builder()
+                .isSuccess(true)
                 .httpStatus(200)
                 .message("success")
                 .data(data)
@@ -30,6 +33,7 @@ public class RestResponse<T> {
 
     public static RestResponse<Void> ok() {
         return RestResponse.<Void>builder()
+                .isSuccess(true)
                 .httpStatus(200)
                 .message("success")
                 .build();
@@ -37,6 +41,7 @@ public class RestResponse<T> {
 
     public static RestResponse<Void> onFailure(ErrorCode errorCode) {
         return RestResponse.<Void>builder()
+                .isSuccess(false)
                 .httpStatus(200)
                 .message(errorCode.getMessage())
                 .build();

--- a/src/main/java/com/itstime/xpact/global/response/RestResponse.java
+++ b/src/main/java/com/itstime/xpact/global/response/RestResponse.java
@@ -1,6 +1,7 @@
 package com.itstime.xpact.global.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.itstime.xpact.global.exception.ErrorCode;
 import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Data;
@@ -31,6 +32,13 @@ public class RestResponse<T> {
         return RestResponse.<Void>builder()
                 .httpStatus(200)
                 .message("success")
+                .build();
+    }
+
+    public static RestResponse<Void> onFailure(ErrorCode errorCode) {
+        return RestResponse.<Void>builder()
+                .httpStatus(200)
+                .message(errorCode.getMessage())
                 .build();
     }
 }

--- a/src/main/java/com/itstime/xpact/global/security/controller/FormLoginController.java
+++ b/src/main/java/com/itstime/xpact/global/security/controller/FormLoginController.java
@@ -1,6 +1,6 @@
 package com.itstime.xpact.global.security.controller;
 
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.response.ErrorResponse;
 import com.itstime.xpact.global.response.RestResponse;
 import com.itstime.xpact.global.security.dto.request.LoginRequestDto;
@@ -49,7 +49,7 @@ public class FormLoginController {
     public ResponseEntity<RestResponse<?>> formLogin(
             @RequestBody LoginRequestDto requestDto,
             HttpServletResponse response
-    ) throws CustomException {
+    ) throws GeneralException {
         return ResponseEntity.ok(
                 RestResponse.ok(
                         formLoginService.generalLogin(requestDto, response)
@@ -76,7 +76,7 @@ public class FormLoginController {
     @PostMapping("/signup")
     public ResponseEntity<RestResponse<SignupResponseDto>> signup (
             @RequestBody SignupRequestDto signupRequestDto
-    ) throws CustomException{
+    ) throws GeneralException {
 
         return ResponseEntity.ok(
                 RestResponse.ok(
@@ -131,7 +131,7 @@ public class FormLoginController {
     @PostMapping("/refresh")
     public ResponseEntity<RestResponse<?>> refresh(
             HttpServletRequest request, HttpServletResponse response
-    ) throws CustomException {
+    ) throws GeneralException {
         return ResponseEntity.ok(
                 RestResponse.ok(
                         formLoginService.refresh(request, response)));

--- a/src/main/java/com/itstime/xpact/global/security/controller/KakaoLoginController.java
+++ b/src/main/java/com/itstime/xpact/global/security/controller/KakaoLoginController.java
@@ -1,6 +1,6 @@
 package com.itstime.xpact.global.security.controller;
 
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.response.ErrorResponse;
 import com.itstime.xpact.global.response.RestResponse;
 import com.itstime.xpact.global.security.service.KakaoLoginService;
@@ -63,7 +63,7 @@ public class KakaoLoginController {
     public ResponseEntity<RestResponse<?>> callback(
             @Parameter(description = "카카오로부터 얻은 인증 코드")
             @RequestParam String code,
-            HttpServletResponse response) throws CustomException {
+            HttpServletResponse response) throws GeneralException {
         return ResponseEntity.ok(
                 RestResponse.ok(kakaoLoginService.login(code, response)));
     }

--- a/src/main/java/com/itstime/xpact/global/security/service/FormLoginService.java
+++ b/src/main/java/com/itstime/xpact/global/security/service/FormLoginService.java
@@ -5,14 +5,13 @@ import com.itstime.xpact.domain.member.common.Type;
 import com.itstime.xpact.domain.member.entity.Member;
 import com.itstime.xpact.domain.member.repository.MemberRepository;
 import com.itstime.xpact.global.auth.TokenProvider;
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 import com.itstime.xpact.global.security.common.LoginStrategy;
 import com.itstime.xpact.global.security.dto.request.LoginRequestDto;
 import com.itstime.xpact.global.security.dto.request.SignupRequestDto;
 import com.itstime.xpact.global.security.dto.response.LoginResponseDto;
 import com.itstime.xpact.global.security.dto.response.SignupResponseDto;
-import com.itstime.xpact.global.security.util.KakaoUtil;
 import com.itstime.xpact.global.security.util.RefreshTokenUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -40,12 +39,12 @@ public class FormLoginService implements LoginStrategy {
 
     // 회원 가입 서비스
     @Transactional
-    public SignupResponseDto register(SignupRequestDto requestDto) throws CustomException {
+    public SignupResponseDto register(SignupRequestDto requestDto) throws GeneralException {
 
         // 회원 가입 여부 확인
         if (memberRepository.existsByEmail(requestDto.email())) {
             log.warn("이미 존재하는 회원입니다.");
-            throw CustomException.of(ErrorCode.MEMBER_ALREADY_EXISTS);
+            throw GeneralException.of(ErrorCode.MEMBER_ALREADY_EXISTS);
         }
 
         log.info("{" + requestDto.email() + "} :  회원 가입 시작");
@@ -70,17 +69,17 @@ public class FormLoginService implements LoginStrategy {
     public LoginResponseDto generalLogin(
             LoginRequestDto requestDto,
             HttpServletResponse httpResponse
-    ) throws CustomException{
+    ) throws GeneralException {
 
         // 가입된 회원인지 조회
         log.info(requestDto.email() + "의 회원 조회를 시작합니다.");
         Member member = memberRepository.findByEmail(requestDto.email())
-                .orElseThrow(() -> CustomException.of(ErrorCode.MEMBER_NOT_EXISTS));
+                .orElseThrow(() -> GeneralException.of(ErrorCode.MEMBER_NOT_EXISTS));
 
         // 비밀번호 검증
         log.info("비밀번호 검증을 시작합니다.");
         if (!passwordEncoder.matches(requestDto.password(), member.getPassword())) {
-            throw new CustomException(ErrorCode.UNMATCHED_PASSWORD);
+            throw new GeneralException(ErrorCode.UNMATCHED_PASSWORD);
         }
         log.info("로그인에 성공하였습니다.");
 
@@ -111,12 +110,12 @@ public class FormLoginService implements LoginStrategy {
     @Transactional
     public String refresh(
             HttpServletRequest request, HttpServletResponse response
-    ) throws CustomException {
+    ) throws GeneralException {
         Long memberId = refreshTokenUtil.getMemberIdFromCookie(request);
 
         log.info(memberId + "의 회원을 조회합니다.");
         Member member = memberRepository.findById(memberId)
-                .orElseThrow(() -> CustomException.of(ErrorCode.MEMBER_NOT_EXISTS));
+                .orElseThrow(() -> GeneralException.of(ErrorCode.MEMBER_NOT_EXISTS));
 
         log.info("Access Token을 재발급합니다.");
         return tokenProvider.generateAccessToken(member);

--- a/src/main/java/com/itstime/xpact/global/security/service/KakaoLoginService.java
+++ b/src/main/java/com/itstime/xpact/global/security/service/KakaoLoginService.java
@@ -5,8 +5,6 @@ import com.itstime.xpact.domain.member.common.Type;
 import com.itstime.xpact.domain.member.entity.Member;
 import com.itstime.xpact.domain.member.repository.MemberRepository;
 import com.itstime.xpact.global.auth.TokenProvider;
-import com.itstime.xpact.global.exception.CustomException;
-import com.itstime.xpact.global.exception.ErrorCode;
 import com.itstime.xpact.global.security.common.LoginStrategy;
 import com.itstime.xpact.global.security.dto.response.KakaoInfoResponseDto;
 import com.itstime.xpact.global.security.dto.response.KakaoTokenDto;

--- a/src/main/java/com/itstime/xpact/global/security/util/KakaoUtil.java
+++ b/src/main/java/com/itstime/xpact/global/security/util/KakaoUtil.java
@@ -1,7 +1,7 @@
 package com.itstime.xpact.global.security.util;
 
 import com.itstime.xpact.global.config.WebClientConfig;
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 import com.itstime.xpact.global.security.dto.response.KakaoInfoResponseDto;
 import com.itstime.xpact.global.security.dto.response.KakaoTokenDto;
@@ -56,7 +56,7 @@ public class KakaoUtil {
                     .block();
         } catch (WebClientResponseException e) {
             log.error("카카오 서버로 AccessToken 요청 중 오류 : {} ", e.getResponseBodyAsString());
-            throw CustomException.of(ErrorCode.ACCESS_TOKEN_REQUEST_FAILED);
+            throw GeneralException.of(ErrorCode.ACCESS_TOKEN_REQUEST_FAILED);
         }
     }
 
@@ -72,7 +72,7 @@ public class KakaoUtil {
                     .block();
         } catch (WebClientResponseException e) {
             log.error("카카오로부터 사용자 Info 요청 중 오류 : {} ", e.getResponseBodyAsString());
-            throw CustomException.of(ErrorCode.ACCESS_TOKEN_REQUEST_FAILED);
+            throw GeneralException.of(ErrorCode.ACCESS_TOKEN_REQUEST_FAILED);
         }
     }
 

--- a/src/main/java/com/itstime/xpact/global/security/util/RefreshTokenUtil.java
+++ b/src/main/java/com/itstime/xpact/global/security/util/RefreshTokenUtil.java
@@ -1,7 +1,7 @@
 package com.itstime.xpact.global.security.util;
 
 import com.itstime.xpact.global.auth.TokenProvider;
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -73,7 +73,7 @@ public class RefreshTokenUtil {
 
         if (cookies == null || cookies.length == 0) {
             log.warn("쿠키가 비어 있습니다.");
-            throw CustomException.of(ErrorCode.EMPTY_COOKIE);
+            throw GeneralException.of(ErrorCode.EMPTY_COOKIE);
         }
 
         for (Cookie cookie : cookies) {
@@ -87,11 +87,11 @@ public class RefreshTokenUtil {
                     return memberId;
                 } else {
                     log.warn("유효하지 않은 Refresh Token입니다.");
-                    throw CustomException.of(ErrorCode.INVALID_JWT_TOKEN);
+                    throw GeneralException.of(ErrorCode.INVALID_JWT_TOKEN);
                 }
             }
         }
         log.warn("Refresh token 쿠키를 찾을 수 없습니다.");
-        throw CustomException.of(ErrorCode.TOKEN_NOT_FOUND);
+        throw GeneralException.of(ErrorCode.TOKEN_NOT_FOUND);
     }
 }

--- a/src/main/java/com/itstime/xpact/global/webclient/SchoolApiClient.java
+++ b/src/main/java/com/itstime/xpact/global/webclient/SchoolApiClient.java
@@ -1,7 +1,7 @@
 package com.itstime.xpact.global.webclient;
 
 import com.itstime.xpact.domain.member.repository.SchoolCustomRepositoryImpl;
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -23,7 +23,7 @@ public class SchoolApiClient {
     private static final String SCHOOL_OPEN_API_URL = "/openapi/service/rest/SchoolMajorInfoService/getSchoolMajorInfo";
 
 
-    public void syncAllSchools() throws CustomException {
+    public void syncAllSchools() throws GeneralException {
         int page = 1;
         int numOfRows = 100;
         int totalCount;
@@ -49,7 +49,7 @@ public class SchoolApiClient {
                 page++;
             } catch (Exception e) {
                 log.error("학교 동기화 실패: {}", e.getMessage(), e);
-                throw new CustomException(ErrorCode.PARSING_ERROR);
+                throw new GeneralException(ErrorCode.PARSING_ERROR);
             }
         } while ((page - 1) * numOfRows < totalCount);
     }

--- a/src/main/java/com/itstime/xpact/infra/lambda/LambdaUtil.java
+++ b/src/main/java/com/itstime/xpact/infra/lambda/LambdaUtil.java
@@ -2,7 +2,7 @@ package com.itstime.xpact.infra.lambda;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.itstime.xpact.global.exception.CustomException;
+import com.itstime.xpact.global.exception.GeneralException;
 import com.itstime.xpact.global.exception.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -54,7 +54,7 @@ public class LambdaUtil {
 
         } catch(LambdaException | JsonProcessingException e) {
             System.out.println(e.getMessage());
-            throw CustomException.of(ErrorCode.INTERNAL_SERVER_ERROR);
+            throw GeneralException.of(ErrorCode.INTERNAL_SERVER_ERROR);
         }
     }
 }

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -18,7 +18,7 @@ spring:
     refresh:
       expiration: 604800 # 7일
     access:
-      expiration: 86400 # 24시간
+      expiration: 900 # 15분 임시 변경
     secret: ${JWT_SECRET_KEY}
 
 


### PR DESCRIPTION
## 🔧 관련 이슈
- closed #115 

## 📌 PR 유형
> 어떤 변경 사항이 있나요?
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링


## 📝 작업 내용
- 기존의 CustomException -> GeneralException으로 이름 변경
- `GeneralException(ErrorCode)` : 예외 로직을 처리해야할 때의 에러사항에 대한 Exception, HttpStatus에 400, 401 등의 일반적인 예외 사항을 던질 때 사용합니다.
- `CustomException(ErrorCode)` : 서버 상에서는 예외로 ExceptionHandler의 대상이지만, HttpStatus로는 200 OK를 반환해야할 때 사용합니다.
```java
@ExceptionHandler(CustomException.class)
    protected ResponseEntity<RestResponse<?>> customException(CustomException e, HttpServletRequest request) {
        logError(e, request);
        return ResponseEntity.status(HttpStatus.OK)
                .body(RestResponse.onFailure(e.getErrorCode())
                );
    }
```
- RestResponse 클래스에 onFailure 메소드를 추가하였습니다

## ✏️ 기타
- AccessToken의 만료 시간을 15분으로 임시 변경하였습니다.
