### PR TITLE
Code Review

### DIFF
--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/ratio/RatioService.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/ratio/RatioService.java
@@ -25,6 +25,7 @@ public class RatioService {
     private final RecruitCountRepository recruitCountRepository;
     private final ExperienceRepository experienceRepository;
 
+
     // 직무 카운트 값을 가져와 직무 비율로 변환하는 로직
     public List<RatioResponseDto> detailRecruitRatio(Long memberId) {
         // 직무 카운트 값 가져옴

--- a/src/main/java/com/itstime/xpact/domain/dashboard/service/skillmap/SkillmapService.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/service/skillmap/SkillmapService.java
@@ -32,6 +32,7 @@ public class SkillmapService {
 
     private final LambdaOpenAiClient lambdaOpenAiClient;
 
+
     /*
     사용자의 모든 경험 요약과, 사용자의 희망 직무에대한 다섯가지 핵심 역량을 입력값으로 사용하여
     각 다섯가지 역량에 맞는 점수를 매기고, AWS람다를 호출하여 분석을 진행

--- a/src/main/java/com/itstime/xpact/domain/experience/service/ExperienceService.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/service/ExperienceService.java
@@ -104,6 +104,11 @@ public class ExperienceService {
         experienceRepository.deleteAllByMember(member);
     }
 
+    /*
+    experience를 통해 openai에 비동기 요청을 보내는 메서드
+    experience -> 요약 및 직무 종류를 도출하여 expericne 엔티티에 저장
+    도출된 데이터는 대시보드를 구현하는데 사용됨
+    */
     private void setSummaryAndDetailRecruit(Experience experience) {
         openAiService.summarizeExperience(experience);
         openAiService.getDetailRecruitFromExperience(experience);


### PR DESCRIPTION
## 📝 질문

### 1. OpenAI 요청 토큰 초과 문제
#### 상황
<img width="600" alt="image" src="https://github.com/user-attachments/assets/c5f2067f-aae9-4951-bc06-af47b64751f0" />
<img width="600" alt="image" src="https://github.com/user-attachments/assets/61ba2cb2-9dbb-49e1-990b-0247928ee94b" />

- 대시보드 API에는 사용자의 요약된 모든 경험 정보를 프롬프트의 input 데이터로 하여 준비된 5가지의 특정 기준에 대해 정량적인 응답을 리턴하는 OpenAI 요청을 포함하고 있습니다.

#### 문제
- 해당 과정에서 사용자의 경험 데이터가 많아져 OpenAI에 보낼 수 있는 토큰의 개수가 초과되는 상황이 발생합니다.
- 이에 토큰 제한량이 더 큰 모델로 바꿔야하는지, 아니면 더 좋은 구현 방법이 있는지 여쭤보고 싶습니다.

---


### 2. 대시보드 분석 로직의 OpenAI 요청 타이밍 문제 : 실시간 vs 사전 처리
#### 상황
- 대시보드 API는 사용자의 경험 정보를 분석하여 분석 결과를 응답으로 내놓습니다.
- 이때 OpenAI가 분석결과를 내놓을 때까지 대기해야 합니다.
- 이에 2가지의 구현 방식을 생각했습니다.

1. 대시보드 API 호출 시마다 OpenAI 요청 + Redis 캐시 사용
<img width="700" alt="image" src="https://github.com/user-attachments/assets/dd53b731-3d0b-43b9-8a64-a3ec4fd81084" />


- 대시보드 API를 호출할 때, OpenAI에 분석 요청을 보내고자 합니다.
- 이때 분석 요청은 대략 5~10초정도 걸립니다.
- Redis를 사용하여 분석 결과를 저장하고, 후에 대시보드 API를 호출했을 때 데이터가 hit되면 해당 데이터를 반환하여 높은 응답시간을 줄이고자 합니다.
  
2. 경험 생성시마다 OpenAI 분석 요청
<img width="600" alt="image" src="https://github.com/user-attachments/assets/1cbf5e92-dac2-4658-8951-563bd736bd87" />


- 대시보드 분석은 사용자의 경험 데이터에 의존하므로, 사용자가 경험을 생성할 때마다 대시보드 분석 요청을 보내고자 합니다.
- 대시보드 API를 호출하면, 경험 생성시 응답받은 대시보드 정보를 조회하여 응답 값으로 보내게 됩니다.

   
#### 문제
- 이 두 방식 중 어떠한 방식이 성능 측면에서 좋을지 조언을 구하고 싶습니다. 적은 OpenAI요청으로,  대시보드에 사용자의 최신 경험 정보를 반영하고자 합니다.


---

### 3. 실제 서비스를 출시한다면 어떤 환경의 서버에서 운영하는 것이 좋은지에 대해 여쭤보고싶습니다


---

### 4. 서버가 예상치 못하게 다운되었을 때 이를 감지하여 알림을 전송하고, 대응조치를 수행할 수 있는 방법에 대해 여쭤보고 싶습니다.