### PR TITLE
fix/#137 : sort 로직 추가

### DIFF
--- a/src/main/java/com/itstime/xpact/domain/experience/repository/ExperienceCustomRepository.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/repository/ExperienceCustomRepository.java
@@ -15,5 +15,5 @@ public interface ExperienceCustomRepository {
 
     List<Experience> queryExperience(Member member, String query);
 
-    List<Experience> findAllByMember(Member member, Sort sort);
+    List<Experience> findAllByMember(Member member, String order);
 }

--- a/src/main/java/com/itstime/xpact/domain/experience/repository/ExperienceCustomRepositoryImpl.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/repository/ExperienceCustomRepositoryImpl.java
@@ -23,11 +23,19 @@ public class ExperienceCustomRepositoryImpl implements ExperienceCustomRepositor
 
     private final JPAQueryFactory queryFactory;
 
-    public List<Experience> findAllByMember(Member member, Sort sort) {
+    public List<Experience> findAllByMember(Member member, String order) {
         QExperience experience = QExperience.experience;
+
+        OrderSpecifier<?> orderSpecifier = null;
+        if(order.equals("LATEST")) {
+            orderSpecifier = new OrderSpecifier<>(Order.DESC, experience.modifiedTime);
+        } else if(order.equals("OLDEST")) {
+            orderSpecifier = new OrderSpecifier<>(Order.ASC, experience.modifiedTime);
+        }
 
         return queryFactory.selectFrom(experience)
                 .where(experience.member.id.eq(member.getId()))
+                .orderBy(orderSpecifier)
                 .fetch();
     }
 

--- a/src/main/java/com/itstime/xpact/domain/experience/service/QueryExperienceService.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/service/QueryExperienceService.java
@@ -35,13 +35,7 @@ public class QueryExperienceService {
         Member member = securityProvider.getCurrentMember();
 
         if(types.get(0).equalsIgnoreCase("all")) {
-            Sort sort = null;
-            switch (order) {
-                case OLDEST -> sort = Sort.by(Sort.Direction.ASC, MODIFIED);
-                case LATEST -> sort = Sort.by(Sort.Direction.DESC, MODIFIED);
-            }
-
-            return experienceRepository.findAllByMember(member, sort)
+            return experienceRepository.findAllByMember(member, order)
                     .stream()
                     .map(ThumbnailExperienceWithkeywordResponseDto::of)
                     .toList();


### PR DESCRIPTION
## 🔧 관련 이슈
- closed #137 

## 📌 PR 유형
- [x] 버그 수정

## 📝 작업 내용
- 경험 목록 조회 시 정렬 기능 누락되었음
- 이를 추가하여 정렬 기능 정상화
- 정렬 로직을 service단이 아닌 repository단으로 이동

## ✏️ 기타
