### PR TITLE
feature/#165 : visualVM 사용 위한 포트 열기 (1099) & 실행 옵션 추가

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,4 +3,15 @@ FROM openjdk:17-jdk
 ARG JAR_FILE=build/libs/xpact-0.0.1-SNAPSHOT.jar
 COPY ${JAR_FILE} /xpact.jar
 
-ENTRYPOINT ["java", "-jar", "-Dspring.profiles.active=dev", "-Duser.timezone=Asia/Seoul", "/xpact.jar"]
+ENTRYPOINT ["java",
+    "-jar",
+    "-Dspring.profiles.active=dev",
+    "-Duser.timezone=Asia/Seoul",
+    "-Dcom.sun.management.jmxremote=true",
+    "-Dcom.sun.management.jmxremote.local.only=false",
+    "-Dcom.sun.management.jmxremote.port=1099",
+    "-Dcom.sun.management.jmxremote.ssl=false",
+    "-Djava.rmi.server.hostname=3.39.122.216",
+    "-Dcom.sun.management.jmxremote.rmi.port=1099",
+    "-Dcom.sun.management.jmxremote.authenticate=false",
+    "/xpact.jar"]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,6 +4,7 @@ services:
     container_name: xpact-api
     ports:
       - "8080:8080"
+      - "1099:1099"
     env_file:
       - /home/ubuntu/xpact-api/.env
     volumes:


### PR DESCRIPTION
## 🔧 관련 이슈
- closed #165

## 📌 PR 유형
- [x] 새로운 기능 추가

## 📝 작업 내용
- visualVM과 연결 위한 docker conatiner 포트 추가 (1099)
- visualVM 실행 설정 값 Dockerfile CMD에 추가

## ✏️ 기타
