### PR TITLE
Fix/#171/refresh dashboard

### DIFF
--- a/src/main/java/com/itstime/xpact/domain/experience/converter/ExperienceConverter.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/converter/ExperienceConverter.java
@@ -18,7 +18,7 @@ import org.springframework.stereotype.Component;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import static com.itstime.xpact.domain.experience.common.ExperienceType.IS_QUALIFICATION;
@@ -133,12 +133,12 @@ public class ExperienceConverter {
         subExperience.getFiles().clear();
 
         List<File> fileList = Stream.concat(
-                files.stream().map(url -> File.builder()
+                Optional.ofNullable(files).orElseGet(List::of).stream().map(url -> File.builder()
                         .fileType(FileType.FILE)
                         .fileUrl(url)
                         .subExperience(subExperience)
                         .build()),
-                links.stream().map(link -> File.builder()
+                Optional.ofNullable(links).orElseGet(List::of).stream().map(link -> File.builder()
                         .fileType(FileType.LINK)
                         .fileUrl(link)
                         .subExperience(subExperience)

--- a/src/main/java/com/itstime/xpact/domain/experience/entity/Experience.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/entity/Experience.java
@@ -22,7 +22,6 @@ import static com.itstime.xpact.domain.experience.common.ExperienceType.IS_QUALI
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-@ToString(exclude = {"detailRecruit", "member", "status", "summary", "subExperiences"})
 public class Experience extends BaseEntity {
 
     @Id
@@ -101,4 +100,15 @@ public class Experience extends BaseEntity {
             this.isEnded = updateRequestDto.getEndDate().isBefore(LocalDate.now());
         }
     }
+
+    @Override
+    public String toString() {
+        return "Experience{" +
+                ", experienceType=" + experienceType +
+                ", title='" + title + '\'' +
+                ", qualification='" + qualification + '\'' +
+                ", publisher='" + publisher + '\'' +
+                '}';
+    }
+
 }

--- a/src/main/java/com/itstime/xpact/domain/experience/entity/SubExperience.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/entity/SubExperience.java
@@ -21,7 +21,6 @@ import static com.itstime.xpact.domain.experience.common.ExperienceType.IS_QUALI
 @NoArgsConstructor
 @AllArgsConstructor
 @Table(name = "sub_experience")
-@ToString(exclude = {"id", "tabName", "experience"})
 public class SubExperience extends BaseEntity {
 
     @Id
@@ -104,4 +103,17 @@ public class SubExperience extends BaseEntity {
             }
         }
     }
+
+    @Override
+    public String toString() {
+        return "SubExperience{" +
+                ", subTitle='" + subTitle + '\'' +
+                ", keywords='" + keywords.stream()
+                .map(Keyword::getName)+ '\'' +
+                ", starForm='" + starForm + '\'' +
+                ", simpleForm='" + simpleForm + '\'' +
+                ", simpleDescription='" + simpleDescription + '\'' +
+                '}';
+    }
+
 }

--- a/src/main/java/com/itstime/xpact/domain/experience/entity/embeddable/SimpleForm.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/entity/embeddable/SimpleForm.java
@@ -6,7 +6,6 @@ import lombok.*;
 
 @Getter
 @Builder
-@ToString
 @Embeddable
 @NoArgsConstructor
 @AllArgsConstructor
@@ -16,4 +15,12 @@ public class SimpleForm {
     private String role;
     @Column(name = "perform", length = 512)
     private String perform;
+
+    @Override
+    public String toString() {
+        return "SimpleForm{" +
+                "role='" + role + '\'' +
+                ", perform='" + perform + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/com/itstime/xpact/domain/experience/entity/embeddable/StarForm.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/entity/embeddable/StarForm.java
@@ -6,7 +6,6 @@ import lombok.*;
 
 @Getter
 @Builder
-@ToString
 @Embeddable
 @NoArgsConstructor
 @AllArgsConstructor
@@ -20,4 +19,14 @@ public class StarForm {
     private String action;
     @Column(name = "result", length = 512)
     private String result;
+
+    @Override
+    public String toString() {
+        return "starForm{" +
+                "situation='" + situation + '\'' +
+                ", task='" + task + '\'' +
+                ", action='" + action + '\'' +
+                ", result='" + result + '\'' +
+                '}';
+    }
 }

--- a/src/main/java/com/itstime/xpact/domain/experience/repository/ExperienceRepository.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/repository/ExperienceRepository.java
@@ -32,4 +32,7 @@ public interface ExperienceRepository extends JpaRepository<Experience, Long>, E
     List<Object[]> countByDay(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate, Member member);
 
     void deleteAllByMember(Member member);
+
+    @Query("SELECT e FROM Experience e LEFT JOIN FETCH e.subExperiences")
+    List<Experience> findAllWithSubExperiences();
 }

--- a/src/main/java/com/itstime/xpact/domain/experience/service/ExperienceScheduler.java
+++ b/src/main/java/com/itstime/xpact/domain/experience/service/ExperienceScheduler.java
@@ -1,0 +1,36 @@
+package com.itstime.xpact.domain.experience.service;
+
+import com.itstime.xpact.domain.experience.entity.Experience;
+import com.itstime.xpact.domain.experience.entity.SubExperience;
+import com.itstime.xpact.domain.experience.repository.ExperienceRepository;
+import com.itstime.xpact.global.openai.OpenAiService;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+@Transactional
+public class ExperienceScheduler {
+
+    private final ExperienceRepository experienceRepository;
+    private final OpenAiService openAiService;
+
+    @Scheduled(cron = "0 0 4 * * *")
+    public void checkSummarizedExperience() {
+        List<Experience> experiences = experienceRepository.findAllWithSubExperiences();
+        log.info("Check all of Experiences...");
+        for (Experience experience : experiences) {
+            if (experience.getSummary() == null) {
+                log.info("Insert summarization to Experience : {}...", experience.getId());
+                List<SubExperience> subExperiences = experience.getSubExperiences();
+                openAiService.summarizeExperience(experience, subExperiences);
+            }
+        }
+    }
+}

--- a/src/main/java/com/itstime/xpact/domain/member/dto/response/MypageInfoResponseDto.java
+++ b/src/main/java/com/itstime/xpact/domain/member/dto/response/MypageInfoResponseDto.java
@@ -24,6 +24,9 @@ public record MypageInfoResponseDto (
                 example = "잇타대학교 잇타학과 재학")
         String educationName,
 
+        @Schema(description = "재학 / 휴학 ")
+        String schoolState,
+
         @Schema(description = "희망 직무",
                 example = "서비스 기획자")
         String desiredDetailRecruit

--- a/src/main/java/com/itstime/xpact/domain/member/entity/Member.java
+++ b/src/main/java/com/itstime/xpact/domain/member/entity/Member.java
@@ -106,6 +106,7 @@ public class Member extends BaseEntity {
                                 ? member.getEducation().getEducationName()
                                 : null
                 )
+                .schoolState(member.getEducation().getSchoolStatus().getDisplayName())
                 .desiredDetailRecruit(member.getDesiredRecruit() != null ? member.getDesiredRecruit() : null)
                 .build();
     }

--- a/src/main/java/com/itstime/xpact/domain/member/service/EducationService.java
+++ b/src/main/java/com/itstime/xpact/domain/member/service/EducationService.java
@@ -166,7 +166,7 @@ public class EducationService {
         }
 
         String statusName = schoolStatus.getDisplayName();
-        return String.format("%s %s (%s)",
-                name, major, statusName);
+        return String.format("%s %s",
+                name, major);
     }
 }


### PR DESCRIPTION
## 🔧 관련 이슈
- closed #171 

## 📌 PR 유형
- [x] 새로운 기능 추가
- [x] 코드 리팩토링

## 📝 작업 내용
- Experience의 summary 필드가 기능 상 중요하기에 누락이 있을 경우 채워주는 스케줄러를 구현하였습니다.
![image](https://github.com/user-attachments/assets/9aa84f2d-400c-4467-ad0a-fe0d96b0f6e2)

## 🔫 트러블슈팅
```
org.hibernate.LazyInitializationException: failed to lazily initialize a collection of role: com.itstime.xpact.domain.experience.entity.Experience.subExperiences: could not initialize proxy - no Session

```
-  `@Async` 메서드가 실행될 때, 인자로 들어가는 객체들이 영속성 컨텍스트(Session) 밖에 있었기에 LAZY 로딩을 시도하는 순간 에러가 발생하는 오류 (어노테이션 ToString을 이용할 경우 자동으로 구현해주되 자식 객체들을 LAZY 로딩으로 접근)
- summary에 필요한 값들을 ToString 어노테이션으로 호출 시에 LAZY와 Async 간의 충돌이 일어나 toString을 직접 구현하고 자식 객체들은 직접 속성값을 통해 호출하였습니다



## ✏️ 기타
