### PR TITLE
Fix/#180/fix feedback

### DIFF
--- a/src/main/java/com/itstime/xpact/domain/dashboard/entity/CoreSkillMap.java
+++ b/src/main/java/com/itstime/xpact/domain/dashboard/entity/CoreSkillMap.java
@@ -8,7 +8,7 @@ import org.springframework.data.redis.core.RedisHash;
 
 @Getter
 @Builder
-@RedisHash(value = "coreSkillMap", timeToLive = 120)
+@RedisHash(value = "coreSkillMap", timeToLive = 600)
 public class CoreSkillMap {
     @Id
     private Long id;

--- a/src/main/java/com/itstime/xpact/domain/guide/controller/GuideController.java
+++ b/src/main/java/com/itstime/xpact/domain/guide/controller/GuideController.java
@@ -49,6 +49,8 @@ public class GuideController {
         return ResponseEntity.ok(RestResponse.ok(guideService.getActivities(weaknessOrder, pageable)));
     }
 
+    @Operation(summary = "공고 상세 조회 API", description = """
+            조회하려는 공고의 아이디를 입력합니다.""")
     @GetMapping("/activities/{activity_id}")
     public ResponseEntity<RestResponse<ScrapDetailResponseDto>> getActivities(@PathVariable(name = "activity_id") Long scrapId) {
         return ResponseEntity.ok(RestResponse.ok(guideService.getActivity(scrapId)));

--- a/src/main/java/com/itstime/xpact/domain/guide/entity/Weakness.java
+++ b/src/main/java/com/itstime/xpact/domain/guide/entity/Weakness.java
@@ -50,18 +50,6 @@ public class Weakness extends BaseEntity {
         this.explanation = explanation;
     }
 
-    public Weakness updateWeakness(Member member, List<Weakness> weaknessList) {
-
-        Weakness oldest = weaknessList.stream()
-                .sorted(Comparator.comparing(BaseEntity::getCreatedTime))
-                .findFirst()
-                .orElseThrow(() -> GeneralException.of(ErrorCode.WEAKNESS_NOT_FOUND));
-
-        oldest.setName(name);
-        oldest.setExplanation(explanation);
-        return oldest;
-    }
-
     @Override
     public String toString() {
         return "Weakness{" + "name='" + name + ", explanation='" + explanation + '}';

--- a/src/main/java/com/itstime/xpact/domain/guide/service/GuideService.java
+++ b/src/main/java/com/itstime/xpact/domain/guide/service/GuideService.java
@@ -97,6 +97,7 @@ public class GuideService {
                     Weakness existing = existingWeakness.get(i);
                     existing.setName(newName);
                     existing.setExplanation(explanation);
+                    weaknessRepository.save(existing);
                 } else {
                     // 존재하지 않을 경우
                     savedWeakness.add(new Weakness(member, newName, explanation));

--- a/src/main/java/com/itstime/xpact/domain/guide/service/GuideService.java
+++ b/src/main/java/com/itstime/xpact/domain/guide/service/GuideService.java
@@ -157,7 +157,7 @@ public class GuideService {
         List<String> weaknessNames = weaknessRepository.findByMemberId(member.getId())
                 .stream()
                 .map(Weakness::getName)
-                .filter(name -> name != null && name.isBlank())
+                .filter(name -> name != null && !name.isBlank())
                 .toList();
 
         Set<String> keywordSet = new HashSet<>();

--- a/src/main/java/com/itstime/xpact/global/openai/OpenAiServiceImpl.java
+++ b/src/main/java/com/itstime/xpact/global/openai/OpenAiServiceImpl.java
@@ -136,14 +136,20 @@ public class OpenAiServiceImpl implements OpenAiService {
         StringBuilder builder = new StringBuilder();
         builder.append("다음은 나의 경험들에 대한 요약본이다.\n\n");
         builder.append(experiences).append("\n");
-        builder.append("이에 대하여 나의 약점에 대한 원인 분석을 해주고, 피드백을 해줘. 나의 약점은 ").append(weakness).append("이다.\n");
+        builder.append("나의 약점은 ").append(weakness).append("이다.\n");
 
         PromptTemplate template = new PromptTemplate(String.valueOf(builder));
 
         String message = template.render();
 
         Message userMessage = new UserMessage(message);
-        Message systemMessage = new SystemMessage("350~400 byte 분량으로 답하고 줄바꿈은 없다. 존댓말을 사용해라.");
+
+        Message systemMessage = new SystemMessage(
+                "너는 입력된 경험들을 분석하여 약점의 원인을 파악하고, 그에 맞는 피드백을 제공하는 유능한 조언가다.\n" +
+                        "응답은 친근한 존댓말을 사용한다(예: ~해보세요, ~추천해요)." +
+                        "입력된 경험이 잘 반영된 구체적인 분석을 제공해줘야한다." +
+                        "총 분량은 350~400 byte로, 줄바꿈 없이 한 문단으로 작성해."
+        );
 
         String result = openAiChatModel.call(systemMessage, userMessage);
 


### PR DESCRIPTION
## 🔧 관련 이슈
- closed #180 

## 📌 PR 유형
- [x] 새로운 기능 추가
- [x] 버그 수정
- [x] 문서 수정

## 📝 작업 내용
- Weakness에서 Member 당 약점이 3개가 저장되도록 설정 (JPA에서 save 메소드 누락 해결)
- 실제 update문으로 작동됨 확인 가능
![image](https://github.com/user-attachments/assets/be3cb31c-a155-471b-922a-049a8ffbacfe)
- 기존의 피드백 부분의 응답에 대하여, 역할을 제시하는 프롬프트 엔지니어링을 통해 성능을 높였습니다
![image](https://github.com/user-attachments/assets/d7ce48d0-5b6a-4f89-99e3-231191dcf6f3)

<br>

- AI 추천 기반 검색에서 Redis Cache를 통해 해당 역량에 대한 검색 키워드들을 저장하여 이미 AI에서 추천을 받은 역량에 대해서는 더이상 요청을 보낼 필요 없도록 구현
- 각각의 요청 별로 시간 소요됨(Cache 없을 경우)
![image](https://github.com/user-attachments/assets/97da117a-94f4-42b1-87a3-99ae267e755d)
- Cache가 존재할 경우 속도 빠름 ( 전체 합쳐서 조회하는 것임에도 불구하고 빠름 )
![image](https://github.com/user-attachments/assets/0dd75d70-67ba-407c-9f2b-987ed4bb5811)


## ✏️ 기타
- 역량에 대한 공고 키워드 목록에 대한 Redis TTL은 1일로 설정하였습니다
